### PR TITLE
7_4_5

### DIFF
--- a/Nero/script/setup.sh
+++ b/Nero/script/setup.sh
@@ -1,3 +1,5 @@
 
-#CMSSW_7_4_X
-git cms-merge-topic ikrav:egm_id_74X_v0
+#CMSSW_7_4_2
+#git cms-merge-topic ikrav:egm_id_74X_v0
+
+#CMSSW_7_4_5: nothing to be done

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The Nero directory contains the ntuple producer. It is designed to run on MiniAO
 ### CMSSW compile
 * Notice that cmssw should be init when the src directory is empty
 ```
-cmsrel CMSSW_7_4_2
-cd CMSSW_7_4_2/src
+cmsrel CMSSW_7_4_5
+cd CMSSW_7_4_5/src
 cmsenv
 wget --no-check-certificate 'https://raw.githubusercontent.com/MiT-HEP/NeroProducer/master/Nero/script/setup.sh' -O /tmp/$USER/setup.sh
 source /tmp/$USER/setup.sh


### PR DESCRIPTION
* CMSSW_7_4_2 with the istructions for electron Id is not able to produce miniAOD correctly.
* the fix comes later, when the eID is incorporated in all the process.
* avoid to recompile everything. Now everything is pretty standard.