### PR TITLE
adding virtual ~BareCollection()

### DIFF
--- a/Core/interface/BareCollection.hpp
+++ b/Core/interface/BareCollection.hpp
@@ -19,6 +19,7 @@ class BareCollection
         bool extend_;  // for collection switch to a more inclusive mode
     public:
         BareCollection(){ extend_=false;}
+        virtual ~BareCollection() {}
         virtual void clear() = 0;
         virtual void defineBranches(TTree*) = 0 ;
         virtual void setBranchAddresses(TTree*) = 0;


### PR DESCRIPTION
When filling from Bambu, I use an array of BareCollection*. For this to properly function we need a virtual destructor for BareCollection.