### PR TITLE
Bambu catchups

### DIFF
--- a/Bambu/bambuToNero.py
+++ b/Bambu/bambuToNero.py
@@ -217,12 +217,6 @@ for filler in fillers:
 
 neroMod.SetCondition(photonTightId)
 
-addTrigger('HLT_PFMETNoMu90_NoiseCleaned_PFMHTNoMu90_IDTight_v*')
-addTrigger('HLT_PFMETNoMu120_NoiseCleaned_PFMHTNoMu120_IDTight_v*')
-addTrigger('HLT_Ele27_eta2p1_WPLoose_Gsf_v*')
-addTrigger('HLT_IsoMu27_v*')
-addTrigger('HLT_PFMET170_NoiseCleaned_v*')
-
 sequence = goodPVFilterMod
 if not analysis.isRealData:
     sequence *= generator
@@ -241,6 +235,15 @@ sequence *= separatePileUpMod * \
     fatJetId * \
     photonMediumId * \
     photonTightId
+
+addTrigger('HLT_PFMETNoMu90_NoiseCleaned_PFMHTNoMu90_IDTight_v*')
+addTrigger('HLT_PFMETNoMu120_NoiseCleaned_PFMHTNoMu120_IDTight_v*')
+addTrigger('HLT_IsoMu27_v*')
+addTrigger("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*")
+addTrigger("HLT_Ele27_eta2p1_WPLoose_Gsf_v*")
+addTrigger("HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*")
+addTrigger('HLT_PFMET170_NoiseCleaned_v*')
+addTrigger("HLT_Photon175_v*")
 
 # neroMod must be independent of the main chain
 # to ensure that the all events tree is filled properly

--- a/Bambu/bambuToNero.py
+++ b/Bambu/bambuToNero.py
@@ -4,11 +4,8 @@ import os
 mitdata = os.environ['MIT_DATA']
 
 from MitPhysics.Mods.GoodPVFilterMod import goodPVFilterMod
-from MitPhysics.Mods.JetCorrectionMod import jetCorrectionMod
 from MitPhysics.Mods.JetIdMod import jetIdMod
-from MitPhysics.Mods.MetCorrectionMod import metCorrectionMod
 from MitPhysics.Mods.PFTauIdMod import pfTauIdMod
-pfTauIdMod.AddCutDiscriminator(mithep.PFTau.kDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits, 5., False)
 from MitPhysics.Mods.ElectronIdMod import electronIdMod
 from MitPhysics.Mods.MuonIdMod import muonIdMod
 from MitPhysics.Mods.PhotonIdMod import photonIdMod
@@ -31,30 +28,84 @@ def addTrigger(path):
     triggerFiller.SetTriggerObjectsName(pathNoV, hltMod.GetTrigObjsName())
 
 
-generatorMod = mithep.GeneratorMod(
+generator = mithep.GeneratorMod(
     IsData = False,
     CopyArrays = False,
     MCMETName = "GenMet"
 )
 
+jetCorrectionMod = mithep.JetCorrectionMod(
+    InputName = 'AKt4PFJetsCHS',
+    CorrectedJetsName = 'CorrectedJets',
+    RhoAlgo = mithep.PileupEnergyDensity.kFixedGridFastjetAll
+)
+if analysis.isRealData:
+    jetCorrectionMod.AddCorrectionFromFile(mitdata + "/74X_dataRun2_Prompt_v1_L1FastJet_AK4PFchs.txt")
+    jetCorrectionMod.AddCorrectionFromFile(mitdata + "/74X_dataRun2_Prompt_v1_L2Relative_AK4PFchs.txt")
+    jetCorrectionMod.AddCorrectionFromFile(mitdata + "/74X_dataRun2_Prompt_v1_L3Absolute_AK4PFchs.txt")
+    jetCorrectionMod.AddCorrectionFromFile(mitdata + "/74X_dataRun2_Prompt_v1_L2L3Residual_AK4PFchs.txt")
+else:
+    jetCorrectionMod.AddCorrectionFromFile(mitdata + "/MCRUN2_74_V9_L1FastJet_AK4PFchs.txt")
+    jetCorrectionMod.AddCorrectionFromFile(mitdata + "/MCRUN2_74_V9_L2Relative_AK4PFchs.txt")
+    jetCorrectionMod.AddCorrectionFromFile(mitdata + "/MCRUN2_74_V9_L3Absolute_AK4PFchs.txt")
+
+# Will use independent JetIDMVA that can be used by Nero too
+jetId = jetIdMod.clone(
+    MVATrainingSet = mithep.JetIDMVA.nMVATypes
+)
+
+jetIdMVA = mithep.JetIDMVA()
+jetIdMVA.Initialize(jetIdMod.GetMVACutWP(), mithep.JetIDMVA.kLoose, jetIdMod.GetMVAWeightsFile(), jetIdMod.GetMVACutsFile())
+
+jetId.SetJetIDMVA(jetIdMVA)
+
+metCorrectionMod = mithep.MetCorrectionMod(
+    InputName = 'PFMet',
+    OutputName = 'PFType1CorrectedMet',
+    JetsName = 'AKt4PFJets',
+    RhoAlgo = mithep.PileupEnergyDensity.kFixedGridFastjetAll,
+    MaxEMFraction = 0.9,
+    SkipMuons = True
+)
+metCorrectionMod.ApplyType0(False)
+metCorrectionMod.ApplyType1(True)
+metCorrectionMod.ApplyShift(False)
+metCorrectionMod.IsData(analysis.isRealData)
+if analysis.isRealData:
+    metCorrectionMod.AddJetCorrectionFromFile(mitdata + "/74X_dataRun2_Prompt_v1_L1FastJet_AK4PFchs.txt")
+    metCorrectionMod.AddJetCorrectionFromFile(mitdata + "/74X_dataRun2_Prompt_v1_L2Relative_AK4PFchs.txt")
+    metCorrectionMod.AddJetCorrectionFromFile(mitdata + "/74X_dataRun2_Prompt_v1_L3Absolute_AK4PFchs.txt")
+    metCorrectionMod.AddJetCorrectionFromFile(mitdata + "/74X_dataRun2_Prompt_v1_L2L3Residual_AK4PFchs.txt")
+else:
+    metCorrectionMod.AddJetCorrectionFromFile(mitdata + "/MCRUN2_74_V9_L1FastJet_AK4PF.txt")
+    metCorrectionMod.AddJetCorrectionFromFile(mitdata + "/MCRUN2_74_V9_L2Relative_AK4PF.txt")
+    metCorrectionMod.AddJetCorrectionFromFile(mitdata + "/MCRUN2_74_V9_L3Absolute_AK4PF.txt")
+
+pfTauId = pfTauIdMod.clone('PFTauId')
+pfTauId.AddCutDiscriminator(mithep.PFTau.kDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits, 5., False)
+
+electronLooseId = electronIdMod.clone('ElectronLooseId')
+
 electronTightId = electronIdMod.clone('ElectronTightId',
     IsFilterMode = False,
-    InputName = electronIdMod.GetOutputName(),
+    InputName = electronLooseId.GetOutputName(),
     OutputName = 'TightElectronId',
     IdType = mithep.ElectronTools.kPhys14Tight,
     IsoType = mithep.ElectronTools.kPhys14TightIso
 )
 
+muonLooseId = muonIdMod.clone('MuonLooseId')
+
 muonTightId = muonIdMod.clone('MuonTightId',
     IsFilterMode = False,
-    InputName = muonIdMod.GetOutputName(),
+    InputName = muonLooseId.GetOutputName(),
     OutputName = 'TightMuonId',
     IdType = mithep.MuonTools.kMuonPOG2012CutBasedIdTight,
     IsoType = mithep.MuonTools.kPFIsoBetaPUCorrected
 )
 
 muonTightIdMask = mithep.MaskCollectionMod('TightMuons',
-    InputName = muonIdMod.GetOutputName(),
+    InputName = muonLooseId.GetOutputName(),
     MaskName = muonTightId.GetOutputName(),
     OutputName = 'TightMuons'
 )
@@ -74,15 +125,17 @@ else:
     fatJetCorrectionMod.AddCorrectionFromFile(mitdata + "/MCRUN2_74_V9_L2Relative_AK8PFchs.txt")
     fatJetCorrectionMod.AddCorrectionFromFile(mitdata + "/MCRUN2_74_V9_L3Absolute_AK8PFchs.txt")
 
-fatJetIdMod = jetIdMod.clone('FatJetId',
+fatJetId = jetIdMod.clone('FatJetId',
     InputName = fatJetCorrectionMod.GetOutputName(),
     OutputName = 'GoodFatJets',
     MVATrainingSet = mithep.JetIDMVA.nMVATypes
 )
 
+photonLooseId = photonIdMod.clone('PhotonLooseId')
+
 photonMediumId = photonIdMod.clone('PhotonMediumId',
     IsFilterMode = False,
-    InputName = photonIdMod.GetOutputName(),
+    InputName = photonLooseId.GetOutputName(),
     OutputName = 'PhotonMediumId',
     IdType = mithep.PhotonTools.kPhys14Medium,
     IsoType = mithep.PhotonTools.kPhys14Medium
@@ -108,18 +161,18 @@ fillers.append(mithep.nero.VertexFiller(
 ))
 
 fillers.append(mithep.nero.JetsFiller(
-    JetsName = jetIdMod.GetOutputName(),
+    JetsName = jetId.GetOutputName(),
     VerticesName = goodPVFilterMod.GetOutputName(),
-    JetIDMVA = jetIdMod.GetJetIDMVA()
+    JetIDMVA = jetIdMVA
 ))
 
 fillers.append(mithep.nero.TausFiller(
-    TausName = pfTauIdMod.GetOutputName()
+    TausName = pfTauId.GetOutputName()
 ))
 
 fillers.append(mithep.nero.LeptonsFiller(
-    ElectronsName = electronIdMod.GetOutputName(),
-    MuonsName = muonIdMod.GetOutputName(),
+    ElectronsName = electronLooseId.GetOutputName(),
+    MuonsName = muonLooseId.GetOutputName(),
     ElectronIdsName = electronTightId.GetOutputName(),
     MuonIdsName = muonTightId.GetOutputName(),
     VerticesName = goodPVFilterMod.GetOutputName(),
@@ -129,17 +182,17 @@ fillers.append(mithep.nero.LeptonsFiller(
 ))
 
 fillers.append(mithep.nero.FatJetsFiller(
-    FatJetsName = fatJetIdMod.GetOutputName()
+    FatJetsName = fatJetId.GetOutputName()
 ))
 
 fillers.append(mithep.nero.MetFiller(
     MetName = metCorrectionMod.GetOutputName(),
     MuonsName = muonTightIdMask.GetOutputName(),
-    GenMetName = generatorMod.GetMCMETName()
+    GenMetName = generator.GetMCMETName()
 ))
 
 fillers.append(mithep.nero.PhotonsFiller(
-    PhotonsName = photonIdMod.GetOutputName(),
+    PhotonsName = photonLooseId.GetOutputName(),
     MediumIdName = photonMediumId.GetOutputName(),
     TightIdName = photonTightId.GetOutputName(),
     VerticesName = goodPVFilterMod.GetOutputName()
@@ -148,6 +201,9 @@ fillers.append(mithep.nero.PhotonsFiller(
 fillers.append(mithep.nero.MonteCarloFiller())
 
 fillers.append(mithep.nero.AllFiller())
+
+triggerFiller = mithep.nero.TriggerFiller()
+fillers.append(triggerFiller)
 
 neroMod = mithep.NeroMod(
     Info = 'Nero',
@@ -159,37 +215,37 @@ neroMod = mithep.NeroMod(
 for filler in fillers:
     neroMod.AddFiller(filler)
 
-sequence = goodPVFilterMod
-if not analysis.isRealData:
-    sequence *= generatorMod
+neroMod.SetCondition(photonTightId)
 
-sequence *= separatePileUpMod * \
-    jetCorrectionMod * \
-    jetIdMod * \
-    metCorrectionMod * \
-    pfTauIdMod * \
-    electronIdMod * \
-    muonIdMod * \
-    photonIdMod * \
-    electronTightId * \
-    muonTightId * \
-    muonTightIdMask * \
-    fatJetCorrectionMod * \
-    fatJetIdMod * \
-    photonMediumId * \
-    photonTightId * \
-    neroMod
-
-triggerFiller = mithep.nero.TriggerFiller()
 addTrigger('HLT_PFMETNoMu90_NoiseCleaned_PFMHTNoMu90_IDTight_v*')
 addTrigger('HLT_PFMETNoMu120_NoiseCleaned_PFMHTNoMu120_IDTight_v*')
 addTrigger('HLT_Ele27_eta2p1_WPLoose_Gsf_v*')
 addTrigger('HLT_IsoMu27_v*')
 addTrigger('HLT_PFMET170_NoiseCleaned_v*')
 
-neroMod.AddFiller(triggerFiller)
+sequence = goodPVFilterMod
+if not analysis.isRealData:
+    sequence *= generator
+sequence *= separatePileUpMod * \
+    jetCorrectionMod * \
+    jetId * \
+    metCorrectionMod * \
+    pfTauId * \
+    electronLooseId * \
+    muonLooseId * \
+    photonLooseId * \
+    electronTightId * \
+    muonTightId * \
+    muonTightIdMask * \
+    fatJetCorrectionMod * \
+    fatJetId * \
+    photonMediumId * \
+    photonTightId
+
+# neroMod must be independent of the main chain
+# to ensure that the all events tree is filled properly
+sequence += neroMod
 
 analysis.SetAllowNoHLTTree(True)
 
 analysis.setSequence(sequence)
-

--- a/Bambu/interface/MetFiller.h
+++ b/Bambu/interface/MetFiller.h
@@ -9,7 +9,7 @@ namespace mithep {
 
     class MetFiller : public BaseFiller {
     public:
-      MetFiller() {}
+      MetFiller() { out_.SetExtend(); }
       ~MetFiller() {}
 
       BareCollection* getObject() override { return &out_; }

--- a/Bambu/interface/NeroMod.h
+++ b/Bambu/interface/NeroMod.h
@@ -24,6 +24,7 @@ namespace mithep {
     void SetInfo(char const* _info) { info_.SetTitle(_info); }
     void SetFileName(char const* _name) { fileName_ = _name; }
     void AddFiller(nero::BaseFiller* _filler) { filler_[_filler->collection()] = _filler; }
+    void SetCondition(BaseMod* _mod) { condition_ = _mod; }
 
     void SetPrintLevel(unsigned _l) { printLevel_ = _l; }
 
@@ -43,6 +44,8 @@ namespace mithep {
     TNamed info_{"info", "Nero"};
 
     nero::BaseFiller* filler_[nero::nCollections] = {};
+
+    BaseMod* condition_ = 0;
 
     unsigned printLevel_ = 0;
 

--- a/Bambu/source/NeroMod.cc
+++ b/Bambu/source/NeroMod.cc
@@ -106,7 +106,35 @@ mithep::NeroMod::SlaveTerminate()
 void
 mithep::NeroMod::Process()
 {
+  // always fill allevents
+  nero::AllFiller* allFiller = 0;
+
+  if (filler_[nero::kAll]) {
+    allFiller = static_cast<nero::AllFiller*>(filler_[nero::kAll]);
+    if (printLevel_ > 1)
+      std::cout << "filling " << allFiller->getObject()->name() << std::endl;
+
+    allFiller->getObject()->clear();
+    try {
+      allFiller->callFill();
+    }
+    catch (std::exception& ex) {
+      std::cerr << ex.what() << std::endl;
+      AbortAnalysis();
+    }
+
+    if (printLevel_ > 1)
+      std::cout << "filled " << allFiller->getObject()->name() << std::endl;
+  }
+
+  // skip event if condition module is aborted
+  if (condition_ && !condition_->IsActive())
+    return;
+
   for (auto* filler : filler_) {
+    if (filler == allFiller)
+      continue;
+
     if (filler) {
       if (printLevel_ > 1)
         std::cout << "filling " << filler->getObject()->name() << std::endl;

--- a/Core/src/BareMet.cpp
+++ b/Core/src/BareMet.cpp
@@ -28,11 +28,11 @@ void BareMet::clear(){
 
     if (extend_)
     {
-        metNoMu -> Clear();
-        pfMet_e3p0 -> Clear();
-        metChargedHadron -> Clear();
-        metNeutralHadron -> Clear();
-        metNeutralEM -> Clear();
+        *metNoMu *= 0.;
+        *pfMet_e3p0 *= 0.;
+        *metChargedHadron *= 0.;
+        *metNeutralHadron *= 0.;
+        *metNeutralEM *= 0.;
     }
 }
 
@@ -51,14 +51,19 @@ void BareMet::defineBranches(TTree *t){
     //
     if ( IsExtend() )
     {
+        metNoMu = new TLorentzVector;
         t->Branch("metNoMu","TLorentzVector",&metNoMu);
         //
+        pfMet_e3p0 = new TLorentzVector;
         t->Branch("pfMet_e3p0","TLorentzVector",&pfMet_e3p0);
         //
+        metChargedHadron = new TLorentzVector;
         t->Branch("metChargedHadron","TLorentzVector",&metChargedHadron);
         //
+        metNeutralHadron = new TLorentzVector;
         t->Branch("metNeutralHadron","TLorentzVector",&metNeutralHadron);
         //
+        metNeutralEM = new TLorentzVector;
         t->Branch("metNeutralEM","TLorentzVector",&metNeutralEM);
     }
     //
@@ -77,10 +82,15 @@ void BareMet::setBranchAddresses(TTree *t){
 
     if ( IsExtend() ) 
     {
+        metNoMu = new TLorentzVector;
         t->SetBranchAddress("metNoMu", &metNoMu);
+        pfMet_e3p0 = new TLorentzVector;
         t->SetBranchAddress("pfMet_e3p0", &pfMet_e3p0);
+        metChargedHadron = new TLorentzVector;
         t->SetBranchAddress("metChargedHadron", &metChargedHadron);
+        metNeutralHadron = new TLorentzVector;
         t->SetBranchAddress("metNeutralHadron", &metNeutralHadron);
+        metNeutralEM = new TLorentzVector;
         t->SetBranchAddress("metNeutralEM", &metNeutralEM);
     }
 }


### PR DESCRIPTION
More of fixes than catching up - still a lot of branches need to be filled (especially the recent updates to BarePhoton)

* BareMet: Adding new-constructors to the new MET variables and clearing them using `*= 0.;' instead of Clear() (which doesn't do anything).
* bambuToNero.py: Cloning imported default setups. No change to the actual functionality, but becomes important in the next version of runOnDatasets.py.
* NeroMod: Should now be used as an independent super module in the Bambu job sequence so that all events get processed regardless of skim modules beforehand.