### PR TITLE
removing PUJetId cut from JetIdMod

### DIFF
--- a/Bambu/interface/BaseFiller.h
+++ b/Bambu/interface/BaseFiller.h
@@ -28,6 +28,7 @@ namespace mithep {
       virtual void setCrossRef(BaseFiller*[]) {}
 
       virtual void initialize() {} // @SlaveBegin      
+      virtual void finalize() {} // @SlaveTerminate
       virtual void notify() {}
       void callBegin();
       void callFill();

--- a/Bambu/interface/JetsFiller.h
+++ b/Bambu/interface/JetsFiller.h
@@ -17,11 +17,17 @@ namespace mithep {
       BareCollection* getObject() override { return &out_; }
       mithep::nero::Collection collection() const override { return kJets; }
 
+      void initialize() override;
+      void finalize() override;
       void fill() override;
 
       // must be corrected, loose-id jets
       void SetJetsName(char const* _name) { jetsName_ = _name; }
       void SetVerticesName(char const* _name) { verticesName_ = _name; }
+      void SetJetIdCutWP(unsigned _p) { jetIdCutWP_ = _p; }
+      void SetJetIdMVATrainingSet(unsigned _p) { jetIdMVATrainingSet_ = _p; }
+      void SetJetIdMVAWeightsFile(char const* _path) { jetIdMVAWeightsFile_ = _path; }
+      void SetJetIdCutsFile(char const* _path) { jetIdCutsFile_ = _path; }
       void SetJetIDMVA(mithep::JetIDMVA* _mva) { jetId_ = _mva; }
 
     private:
@@ -29,7 +35,12 @@ namespace mithep {
 
       TString jetsName_ = "AKt4PFJetsCHS";
       TString verticesName_ = ModNames::gkGoodVertexesName;
-      mithep::JetIDMVA* jetId_ = 0; // not owned
+      JetIDMVA* jetId_ = 0;
+      unsigned jetIdCutWP_ = JetIDMVA::kLoose;
+      unsigned jetIdMVATrainingSet_ = JetIDMVA::nMVATypes;
+      TString jetIdMVAWeightsFile_ = "";
+      TString jetIdCutsFile_ = "";
+      bool ownJetId_ = false;
 
       ClassDef(JetsFiller, 0)
     };

--- a/Bambu/macros/bambuToNero.py
+++ b/Bambu/macros/bambuToNero.py
@@ -85,11 +85,6 @@ jetId = jetIdMod.clone(
     PtMin = 20.
 )
 
-jetIdMVA = mithep.JetIDMVA()
-jetIdMVA.Initialize(jetIdMod.GetMVACutWP(), mithep.JetIDMVA.kLoose, jetIdMod.GetMVAWeightsFile(), jetIdMod.GetMVACutsFile())
-
-jetId.SetJetIDMVA(jetIdMVA)
-
 pfTauId = pfTauIdMod.clone('PFTauId')
 pfTauId.AddCutDiscriminator(mithep.PFTau.kDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits, 5., False)
 
@@ -172,7 +167,10 @@ fillers.append(mithep.nero.VertexFiller(
 fillers.append(mithep.nero.JetsFiller(
     JetsName = jetId.GetOutputName(),
     VerticesName = goodPVFilterMod.GetOutputName(),
-    JetIDMVA = jetIdMVA
+    JetIdCutWP = mithep.JetIDMVA.kLoose,
+    JetIdMVATrainingSet = mithep.JetIDMVA.k53BDTCHSFullPlusRMS,
+    JetIdMVAWeightsFile = mitdata + '/TMVAClassification_5x_BDT_chsFullPlusRMS.weights.xml',
+    JetIdCutsFile = mitdata + '/jetIDCuts_121221.dat'
 ))
 
 fillers.append(mithep.nero.TausFiller(

--- a/Bambu/source/JetsFiller.cc
+++ b/Bambu/source/JetsFiller.cc
@@ -6,6 +6,29 @@
 ClassImp(mithep::nero::JetsFiller)
 
 void
+mithep::nero::JetsFiller::initialize()
+{
+  if (!jetId_ && jetIdMVATrainingSet_ != mithep::JetIDMVA::nMVATypes) {
+    jetId_ = new JetIDMVA();
+    jetId_->Initialize(JetIDMVA::CutType(jetIdCutWP_), JetIDMVA::MVAType(jetIdMVATrainingSet_), jetIdMVAWeightsFile_, jetIdCutsFile_);
+
+    ownJetId_ = true;
+  }
+
+  if (jetId_ && !jetId_->IsInitialized())
+    throw std::runtime_error("JetID not initialized");
+}
+
+void
+mithep::nero::JetsFiller::finalize()
+{
+  if (jetId_ && ownJetId_) {
+    delete jetId_;
+    jetId_ = 0;
+  }
+}
+
+void
 mithep::nero::JetsFiller::fill()
 {
   auto* jets = getSource<mithep::JetCol>(jetsName_);

--- a/Bambu/source/NeroMod.cc
+++ b/Bambu/source/NeroMod.cc
@@ -104,6 +104,16 @@ mithep::NeroMod::BeginRun()
 void
 mithep::NeroMod::SlaveTerminate()
 {
+  for (unsigned iC(0); iC != nero::nCollections; ++iC) {
+    if (!filler_[iC])
+      continue;
+
+    if (printLevel_ > 0)
+      std::cout << "finalizing " << filler_[iC]->getObject()->name() << std::endl;
+
+    filler_[iC]->finalize();
+  }
+
   TFile* outputFile = eventsTree_->GetCurrentFile();
   outputFile->cd();
   outputFile->Write();


### PR DESCRIPTION
Jets are not filtered on PUJetId at the JetIdMod level. PU jet Id value is stored.