### PR TITLE
Adding another lepton ID (using the same ID integer)

### DIFF
--- a/Bambu/interface/LeptonsFiller.h
+++ b/Bambu/interface/LeptonsFiller.h
@@ -19,8 +19,10 @@ namespace mithep {
 
       void SetElectronsName(char const* _name) { electronsName_ = _name; }
       void SetMuonsName(char const* _name) { muonsName_ = _name; }
-      void SetElectronIdsName(char const* _name) { electronIdsName_ = _name; }
-      void SetMuonIdsName(char const* _name) { muonIdsName_ = _name; }
+      void SetElectronIdsAName(char const* _name) { electronIdsAName_ = _name; }
+      void SetMuonIdsAName(char const* _name) { muonIdsAName_ = _name; }
+      void SetElectronIdsBName(char const* _name) { electronIdsBName_ = _name; }
+      void SetMuonIdsBName(char const* _name) { muonIdsBName_ = _name; }
       void SetVerticesName(char const* _name) { verticesName_ = _name; }
       void SetPFCandsName(char const* _name) { pfCandsName_ = _name; }
       void SetNoPUPFCandsName(char const* _name) { nopuPFCandsName_ = _name; }
@@ -31,8 +33,10 @@ namespace mithep {
 
       TString electronsName_ = "Electrons";
       TString muonsName_ = "Muons";
-      TString electronIdsName_ = "ElectronIds";
-      TString muonIdsName_ = "MuonIds";
+      TString electronIdsAName_ = "ElectronIdsA";
+      TString muonIdsAName_ = "MuonIdsA";
+      TString electronIdsBName_ = "ElectronIdsB";
+      TString muonIdsBName_ = "MuonIdsB";
       TString verticesName_ = "PrimaryVertexes";
       TString pfCandsName_ = "PFCandidates";
       TString nopuPFCandsName_ = "PFNoPileup";

--- a/Bambu/macros/bambuToNero.py
+++ b/Bambu/macros/bambuToNero.py
@@ -82,13 +82,21 @@ for jec in jecSources:
 # Will use independent JetIDMVA that can be used by Nero too
 jetId = jetIdMod.clone(
     MVATrainingSet = mithep.JetIDMVA.nMVATypes,
-    PtMin = 20.
+    PtMin = 15.
 )
 
 pfTauId = pfTauIdMod.clone('PFTauId')
 pfTauId.AddCutDiscriminator(mithep.PFTau.kDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits, 5., False)
 
 electronLooseId = electronIdMod.clone('ElectronLooseId')
+
+electronMediumId = electronIdMod.clone('ElectronMediumId',
+    IsFilterMode = False,
+    InputName = electronLooseId.GetOutputName(),
+    OutputName = 'MediumElectronId',
+    IdType = mithep.ElectronTools.kPhys14Loose,
+    IsoType = mithep.ElectronTools.kPhys14LooseIso
+)
 
 electronTightId = electronIdMod.clone('ElectronTightId',
     IsFilterMode = False,
@@ -100,12 +108,20 @@ electronTightId = electronIdMod.clone('ElectronTightId',
 
 muonLooseId = muonIdMod.clone('MuonLooseId')
 
+muonMediumId = muonIdMod.clone('MuonMediumId',
+    IsFilterMode = False,
+    InputName = muonLooseId.GetOutputName(),
+    OutputName = 'MediumMuonId',
+    IdType = mithep.MuonTools.kMuonPOG2012CutBasedIdTight,
+    IsoType = mithep.MuonTools.kPFIsoBetaPUCorrected
+)
+
 muonTightId = muonIdMod.clone('MuonTightId',
     IsFilterMode = False,
     InputName = muonLooseId.GetOutputName(),
     OutputName = 'TightMuonId',
     IdType = mithep.MuonTools.kMuonPOG2012CutBasedIdTight,
-    IsoType = mithep.MuonTools.kPFIsoBetaPUCorrected
+    IsoType = mithep.MuonTools.kPFIsoBetaPUCorrectedTight
 )
 
 muonTightIdMask = mithep.MaskCollectionMod('TightMuons',
@@ -180,8 +196,10 @@ fillers.append(mithep.nero.TausFiller(
 fillers.append(mithep.nero.LeptonsFiller(
     ElectronsName = electronLooseId.GetOutputName(),
     MuonsName = muonLooseId.GetOutputName(),
-    ElectronIdsName = electronTightId.GetOutputName(),
-    MuonIdsName = muonTightId.GetOutputName(),
+    ElectronIdsAName = electronMediumId.GetOutputName(),
+    MuonIdsAName = muonMediumId.GetOutputName(),
+    ElectronIdsBName = electronTightId.GetOutputName(),
+    MuonIdsBName = muonTightId.GetOutputName(),
     VerticesName = goodPVFilterMod.GetOutputName(),
     PFCandsName = mithep.Names.gkPFCandidatesBrn,
     NoPUPFCandsName = separatePileUpMod.GetPFNoPileUpName(),
@@ -241,6 +259,8 @@ sequence *= separatePileUpMod * \
     electronLooseId * \
     muonLooseId * \
     photonLooseId * \
+    electronMediumId * \
+    muonMediumId * \
     electronTightId * \
     muonTightId * \
     muonTightIdMask * \

--- a/Bambu/source/LeptonsFiller.cc
+++ b/Bambu/source/LeptonsFiller.cc
@@ -14,11 +14,15 @@ ClassImp(mithep::nero::LeptonsFiller)
 void
 mithep::nero::LeptonsFiller::fill()
 {
+
   auto* electrons = getSource<mithep::ElectronCol>(electronsName_);
   auto* muons = getSource<mithep::MuonCol>(muonsName_);
 
-  auto* eleTightId = getSource<mithep::NFArrBool>(electronIdsName_);
-  auto* muTightId = getSource<mithep::NFArrBool>(muonIdsName_);
+  auto* eleAId = getSource<mithep::NFArrBool>(electronIdsAName_);
+  auto* muAId = getSource<mithep::NFArrBool>(muonIdsAName_);
+
+  auto* eleBId = getSource<mithep::NFArrBool>(electronIdsBName_);
+  auto* muBId = getSource<mithep::NFArrBool>(muonIdsBName_);
 
   auto* pfCands = getSource<mithep::PFCandidateCol>(pfCandsName_);
   auto* nopuPFCands = getSource<mithep::PFCandidateCol>(nopuPFCandsName_);
@@ -61,7 +65,7 @@ mithep::nero::LeptonsFiller::fill()
 
       out_.pdgId->push_back(11 * ele->Charge());
       out_.iso->push_back(chIso + nhIso + phoIso);
-      out_.tightId->push_back(eleTightId->At(iE));
+      out_.tightId->push_back(eleAId->At(iE)+2*eleBId->At(iE));
       out_.lepPfPt->push_back(0.);
       out_.chIso->push_back(chIso);
       out_.nhIso->push_back(nhIso);
@@ -83,7 +87,7 @@ mithep::nero::LeptonsFiller::fill()
 
       out_.pdgId->push_back(13 * mu->Charge());
       out_.iso->push_back(iso);
-      out_.tightId->push_back(muTightId->At(iM));
+      out_.tightId->push_back(muAId->At(iM)+2*muBId->At(iM));
       if (pf)
         out_.lepPfPt->push_back(pf->Pt());
       else


### PR DESCRIPTION
No change in the data format. Making use of the fact that the lepton ID is an integer, we use it as a bit mask now.