### PR TITLE
trigger name wildcard matching was wrong

### DIFF
--- a/Bambu/macros/bambuToNero.py
+++ b/Bambu/macros/bambuToNero.py
@@ -17,16 +17,15 @@ def addTrigger(path):
     global sequence
     global triggerFiller
 
-    pathNoV = path.replace('_v*', '')
-    hltMod = mithep.HLTMod(pathNoV + 'Mod',
+    hltMod = mithep.HLTMod(path.replace('_v*', 'Mod'),
         AbortIfNotAccepted = False,
         AbortIfNoData = False
     )
     hltMod.AddTrigger(path)
 
     sequence = hltMod * sequence
-    triggerFiller.AddTriggerName(pathNoV)
-    triggerFiller.SetTriggerObjectsName(pathNoV, hltMod.GetTrigObjsName())
+    triggerFiller.AddTriggerName(path)
+    triggerFiller.SetTriggerObjectsName(path, hltMod.GetTrigObjsName())
 
 
 generator = mithep.GeneratorMod(

--- a/Bambu/source/TriggerFiller.cc
+++ b/Bambu/source/TriggerFiller.cc
@@ -33,9 +33,18 @@ mithep::nero::TriggerFiller::begin()
   
   auto* hltTable = getSource<mithep::TriggerTable>(TString::Format("%sFwk", Names::gkHltTableBrn));
   for (auto trigger : triggerNames_) {
-    if (trigger.EndsWith("*"))
+    bool isWildcard(false);
+    if (trigger.EndsWith("*")) {
       trigger.ReplaceAll("*", "");
-    auto* triggerName = hltTable->GetWildcard(trigger);
+      isWildcard = true;
+    }
+
+    TriggerName const* triggerName(0);
+    if (isWildcard)
+      triggerName = hltTable->GetWildcard(trigger);
+    else
+      triggerName = hltTable->Get(trigger);
+
     if (triggerName)
       triggerIds_.push_back(triggerName->Id());
     else


### PR DESCRIPTION
Trigger path name matching was confused. _v* was removed at the python level but should have been done so in the C++ level. Since C++ was passed an _v*-stripped path name, TriggerFiller was matching the path name to the first trigger path that it found where the first part of the path name matched.