### PR TITLE
switching lepton id branch from signed to unsigned

### DIFF
--- a/Bambu/interface/LeptonsFiller.h
+++ b/Bambu/interface/LeptonsFiller.h
@@ -19,10 +19,14 @@ namespace mithep {
 
       void SetElectronsName(char const* _name) { electronsName_ = _name; }
       void SetMuonsName(char const* _name) { muonsName_ = _name; }
-      void SetElectronIdsAName(char const* _name) { electronIdsAName_ = _name; }
       void SetMuonIdsAName(char const* _name) { muonIdsAName_ = _name; }
-      void SetElectronIdsBName(char const* _name) { electronIdsBName_ = _name; }
       void SetMuonIdsBName(char const* _name) { muonIdsBName_ = _name; }
+      void SetMuonIdsCName(char const* _name) { muonIdsCName_ = _name; }
+      void SetMuonIdsDName(char const* _name) { muonIdsDName_ = _name; }
+      void SetElectronIdsAName(char const* _name) { electronIdsAName_ = _name; }
+      void SetElectronIdsBName(char const* _name) { electronIdsBName_ = _name; }
+      void SetElectronIdsCName(char const* _name) { electronIdsCName_ = _name; }
+      void SetElectronIdsDName(char const* _name) { electronIdsDName_ = _name; }
       void SetVerticesName(char const* _name) { verticesName_ = _name; }
       void SetPFCandsName(char const* _name) { pfCandsName_ = _name; }
       void SetNoPUPFCandsName(char const* _name) { nopuPFCandsName_ = _name; }
@@ -33,10 +37,14 @@ namespace mithep {
 
       TString electronsName_ = "Electrons";
       TString muonsName_ = "Muons";
-      TString electronIdsAName_ = "ElectronIdsA";
       TString muonIdsAName_ = "MuonIdsA";
-      TString electronIdsBName_ = "ElectronIdsB";
       TString muonIdsBName_ = "MuonIdsB";
+      TString muonIdsCName_ = "MuonIdsC";
+      TString muonIdsDName_ = "MuonIdsD";
+      TString electronIdsAName_ = "ElectronIdsA";
+      TString electronIdsBName_ = "ElectronIdsB";
+      TString electronIdsCName_ = "ElectronIdsC";
+      TString electronIdsDName_ = "ElectronIdsD";
       TString verticesName_ = "PrimaryVertexes";
       TString pfCandsName_ = "PFCandidates";
       TString nopuPFCandsName_ = "PFNoPileup";

--- a/Bambu/macros/bambuToNero.py
+++ b/Bambu/macros/bambuToNero.py
@@ -89,38 +89,94 @@ pfTauId.AddCutDiscriminator(mithep.PFTau.kDiscriminationByRawCombinedIsolationDB
 
 electronLooseId = electronIdMod.clone('ElectronLooseId')
 
+electronVetoId = electronIdMod.clone('ElectronVetoId',
+    IsFilterMode = False,
+    InputName = electronLooseId.GetOutputName(),
+    OutputName = 'VetoElectronId',
+    ApplyD0Cut = True,
+    ApplyDZCut = True,
+    IdType = mithep.ElectronTools.kSummer15Veto,
+    IsoType = mithep.ElectronTools.kSummer15VetoIso
+)
+
+electronFakeId = electronIdMod.clone('ElectronFakeId',
+    IsFilterMode = False,
+    InputName = electronLooseId.GetOutputName(),
+    OutputName = 'FakeElectronId',
+    ApplyD0Cut = True,
+    ApplyDZCut = True,
+    IdType = mithep.ElectronTools.kSummer15Fake,
+    IsoType = mithep.ElectronTools.kSummer15FakeIso
+)
+
 electronMediumId = electronIdMod.clone('ElectronMediumId',
     IsFilterMode = False,
     InputName = electronLooseId.GetOutputName(),
     OutputName = 'MediumElectronId',
-    IdType = mithep.ElectronTools.kPhys14Loose,
-    IsoType = mithep.ElectronTools.kPhys14LooseIso
+    ApplyD0Cut = True,
+    ApplyDZCut = True,
+    IdType = mithep.ElectronTools.kSummer15Medium,
+    IsoType = mithep.ElectronTools.kSummer15MediumIso
 )
 
 electronTightId = electronIdMod.clone('ElectronTightId',
     IsFilterMode = False,
     InputName = electronLooseId.GetOutputName(),
     OutputName = 'TightElectronId',
-    IdType = mithep.ElectronTools.kPhys14Tight,
-    IsoType = mithep.ElectronTools.kPhys14TightIso
+    ApplyD0Cut = True,
+    ApplyDZCut = True,
+    IdType = mithep.ElectronTools.kSummer15Tight,
+    IsoType = mithep.ElectronTools.kSummer15TightIso
 )
 
 muonLooseId = muonIdMod.clone('MuonLooseId')
 
-muonMediumId = muonIdMod.clone('MuonMediumId',
+muonVetoId = muonIdMod.clone('MuonVetoId',
     IsFilterMode = False,
     InputName = muonLooseId.GetOutputName(),
-    OutputName = 'MediumMuonId',
+    OutputName = 'VetoMuonId',
+    MuonClassType = mithep.MuonTools.kGlobal,
+    IdType = mithep.MuonTools.kNoId,
+    IsoType = mithep.MuonTools.kNoIso,
+    ApplyD0Cut = True,
+    ApplyDZCut = True,
+    PtMin = 10
+)
+
+muonSoftId = muonIdMod.clone('MuonSoftId',
+    IsFilterMode = False,
+    InputName = muonLooseId.GetOutputName(),
+    OutputName = 'VetoSoftId',
+    MuonClassType = mithep.MuonTools.kSoftMuon,
+    IdType = mithep.MuonTools.kNoId,
+    IsoType = mithep.MuonTools.kNoIso,
+    ApplyD0Cut = False,
+    ApplyDZCut = False,
+    PtMin = 3
+)
+
+muonFakeId = muonIdMod.clone('MuonFakeId',
+    IsFilterMode = False,
+    InputName = muonLooseId.GetOutputName(),
+    OutputName = 'FakeMuonId',
+    MuonClassType = mithep.MuonTools.kGlobal,
     IdType = mithep.MuonTools.kMuonPOG2012CutBasedIdTight,
-    IsoType = mithep.MuonTools.kPFIsoBetaPUCorrected
+    IsoType = mithep.MuonTools.kPFIsoBetaPUCorrected,
+    ApplyD0Cut = True,
+    ApplyDZCut = True,
+    PtMin = 10
 )
 
 muonTightId = muonIdMod.clone('MuonTightId',
     IsFilterMode = False,
     InputName = muonLooseId.GetOutputName(),
     OutputName = 'TightMuonId',
+    MuonClassType = mithep.MuonTools.kGlobal,
     IdType = mithep.MuonTools.kMuonPOG2012CutBasedIdTight,
-    IsoType = mithep.MuonTools.kPFIsoBetaPUCorrectedTight
+    IsoType = mithep.MuonTools.kPFIsoBetaPUCorrectedTight,
+    ApplyD0Cut = True,
+    ApplyDZCut = True,
+    PtMin = 10
 )
 
 muonTightIdMask = mithep.MaskCollectionMod('TightMuons',
@@ -156,14 +212,14 @@ photonMediumId = photonIdMod.clone('PhotonMediumId',
     IsFilterMode = False,
     InputName = photonLooseId.GetOutputName(),
     OutputName = 'PhotonMediumId',
-    IdType = mithep.PhotonTools.kPhys14Medium,
-    IsoType = mithep.PhotonTools.kPhys14Medium
+    IdType = mithep.PhotonTools.kSummer15Medium,
+    IsoType = mithep.PhotonTools.kSummer15Medium
 )
 
 photonTightId = photonMediumId.clone('PhotonTightId',
     OutputName = 'PhotonTightId',
-    IdType = mithep.PhotonTools.kPhys14Tight,
-    IsoType = mithep.PhotonTools.kPhys14Tight
+    IdType = mithep.PhotonTools.kSummer15Tight,
+    IsoType = mithep.PhotonTools.kSummer15Tight
 )
 
 head = 'HEAD'
@@ -193,12 +249,16 @@ fillers.append(mithep.nero.TausFiller(
 ))
 
 fillers.append(mithep.nero.LeptonsFiller(
-    ElectronsName = electronLooseId.GetOutputName(),
     MuonsName = muonLooseId.GetOutputName(),
-    ElectronIdsAName = electronMediumId.GetOutputName(),
-    MuonIdsAName = muonMediumId.GetOutputName(),
-    ElectronIdsBName = electronTightId.GetOutputName(),
-    MuonIdsBName = muonTightId.GetOutputName(),
+    MuonIdsAName = muonVetoId.GetOutputName(),
+    MuonIdsBName = muonFakeId.GetOutputName(),
+    MuonIdsCName = muonSoftId.GetOutputName(),
+    MuonIdsDName = muonTightId.GetOutputName(),
+    ElectronsName = electronLooseId.GetOutputName(),
+    ElectronIdsAName = electronVetoId.GetOutputName(),
+    ElectronIdsBName = electronFakeId.GetOutputName(),
+    ElectronIdsCName = electronMediumId.GetOutputName(),
+    ElectronIdsDName = electronTightId.GetOutputName(),
     VerticesName = goodPVFilterMod.GetOutputName(),
     PFCandsName = mithep.Names.gkPFCandidatesBrn,
     NoPUPFCandsName = separatePileUpMod.GetPFNoPileUpName(),
@@ -255,14 +315,18 @@ sequence *= separatePileUpMod * \
     jetId * \
     metCorrSequence * \
     pfTauId * \
-    electronLooseId * \
     muonLooseId * \
-    photonLooseId * \
-    electronMediumId * \
-    muonMediumId * \
-    electronTightId * \
+    muonVetoId * \
+    muonSoftId * \
+    muonFakeId * \
     muonTightId * \
     muonTightIdMask * \
+    electronLooseId * \
+    electronVetoId * \
+    electronFakeId * \
+    electronMediumId * \
+    electronTightId * \
+    photonLooseId * \
     photonMediumId * \
     photonTightId * \
     fatJetCorrection * \

--- a/Bambu/source/LeptonsFiller.cc
+++ b/Bambu/source/LeptonsFiller.cc
@@ -69,7 +69,7 @@ mithep::nero::LeptonsFiller::fill()
         // dZ cut at 10000. -> vertex information is not used
         double puIso(IsolationTools::PFElectronIsolation(ele, puPFCands, vertices->At(0), 10000., 0., 0.3, 0., mithep::PFCandidate::eHadron));
 
-        out_.pdgId->push_back(11 * ele->Charge());
+        out_.pdgId->push_back(-11 * ele->Charge());
         out_.iso->push_back(chIso + nhIso + phoIso);
 
         unsigned selBits = 0;
@@ -104,7 +104,7 @@ mithep::nero::LeptonsFiller::fill()
             pf = pfCands->At(iPF);
         }
 
-        out_.pdgId->push_back(13 * mu->Charge());
+        out_.pdgId->push_back(-13 * mu->Charge());
         out_.iso->push_back(iso);
 
         // careful, different treatment for muons and electrons

--- a/Bambu/source/LeptonsFiller.cc
+++ b/Bambu/source/LeptonsFiller.cc
@@ -18,11 +18,15 @@ mithep::nero::LeptonsFiller::fill()
   auto* electrons = getSource<mithep::ElectronCol>(electronsName_);
   auto* muons = getSource<mithep::MuonCol>(muonsName_);
 
-  auto* eleAId = getSource<mithep::NFArrBool>(electronIdsAName_);
   auto* muAId = getSource<mithep::NFArrBool>(muonIdsAName_);
-
-  auto* eleBId = getSource<mithep::NFArrBool>(electronIdsBName_);
   auto* muBId = getSource<mithep::NFArrBool>(muonIdsBName_);
+  auto* muCId = getSource<mithep::NFArrBool>(muonIdsCName_);
+  auto* muDId = getSource<mithep::NFArrBool>(muonIdsDName_);
+
+  auto* eleAId = getSource<mithep::NFArrBool>(electronIdsAName_);
+  auto* eleBId = getSource<mithep::NFArrBool>(electronIdsBName_);
+  auto* eleCId = getSource<mithep::NFArrBool>(electronIdsCName_);
+  auto* eleDId = getSource<mithep::NFArrBool>(electronIdsDName_);
 
   auto* pfCands = getSource<mithep::PFCandidateCol>(pfCandsName_);
   auto* nopuPFCands = getSource<mithep::PFCandidateCol>(nopuPFCandsName_);
@@ -55,50 +59,77 @@ mithep::nero::LeptonsFiller::fill()
     }
 
     if (ele) {
-      newP4(out_, *ele);
+      // at least one lepton Id should be true
+      if (eleAId->At(iE) || eleBId->At(iE) || eleCId->At(iE) || eleDId->At(iE)){
+        newP4(out_, *ele);
 
-      double chIso(ele->PFChargedHadronIso());
-      double nhIso(ele->PFNeutralHadronIso());
-      double phoIso(ele->PFPhotonIso());
-      // dZ cut at 10000. -> vertex information is not used
-      double puIso(IsolationTools::PFElectronIsolation(ele, puPFCands, vertices->At(0), 10000., 0., 0.3, 0., mithep::PFCandidate::eHadron));
+        double chIso(ele->PFChargedHadronIso());
+        double nhIso(ele->PFNeutralHadronIso());
+        double phoIso(ele->PFPhotonIso());
+        // dZ cut at 10000. -> vertex information is not used
+        double puIso(IsolationTools::PFElectronIsolation(ele, puPFCands, vertices->At(0), 10000., 0., 0.3, 0., mithep::PFCandidate::eHadron));
 
-      out_.pdgId->push_back(11 * ele->Charge());
-      out_.iso->push_back(chIso + nhIso + phoIso);
-      out_.tightId->push_back(eleAId->At(iE)+2*eleBId->At(iE));
-      out_.lepPfPt->push_back(0.);
-      out_.chIso->push_back(chIso);
-      out_.nhIso->push_back(nhIso);
-      out_.phoIso->push_back(phoIso);
-      out_.puIso->push_back(puIso);
+        out_.pdgId->push_back(11 * ele->Charge());
+        out_.iso->push_back(chIso + nhIso + phoIso);
 
+        unsigned selBits = 0;
+        if (eleAId->At(iE))
+          selBits |= BareLeptons::LepVeto;
+        if (eleBId->At(iE))
+          selBits |= BareLeptons::LepFake;
+        if (eleCId->At(iE))
+          selBits |= BareLeptons::LepMedium;
+        if (eleDId->At(iE))
+          selBits |= BareLeptons::LepTight;
+        out_.selBits->push_back(selBits);
+
+        out_.lepPfPt->push_back(0.);
+        out_.chIso->push_back(chIso);
+        out_.nhIso->push_back(nhIso);
+        out_.phoIso->push_back(phoIso);
+        out_.puIso->push_back(puIso);
+      }
       ++iE;
     }
     else {
-      newP4(out_, *mu);
+      // at least one lepton Id should be true
+      if (muAId->At(iM) || muBId->At(iM) || muCId->At(iM) || muDId->At(iM)){
+        newP4(out_, *mu);
 
-      double iso(IsolationTools::BetaMwithPUCorrection(nopuPFCands, puPFCands, mu, 0.4));
+        double iso(IsolationTools::BetaMwithPUCorrection(nopuPFCands, puPFCands, mu, 0.4));
       
-      mithep::PFCandidate* pf = 0;
-      for (unsigned iPF(0); iPF != pfCands->GetEntries(); ++iPF) {
-        if (pfCands->At(iPF)->Mu() == mu)
-          pf = pfCands->At(iPF);
+        mithep::PFCandidate* pf = 0;
+        for (unsigned iPF(0); iPF != pfCands->GetEntries(); ++iPF) {
+          if (pfCands->At(iPF)->Mu() == mu)
+            pf = pfCands->At(iPF);
+        }
+
+        out_.pdgId->push_back(13 * mu->Charge());
+        out_.iso->push_back(iso);
+
+        // careful, different treatment for muons and electrons
+        unsigned selBits = 0;
+        if (muAId->At(iM))
+          selBits |= BareLeptons::LepVeto;
+        if (muBId->At(iM))
+          selBits |= BareLeptons::LepFake;
+        if (muCId->At(iM))
+          selBits |= BareLeptons::LepSoft;
+        if (muDId->At(iM))
+          selBits |= BareLeptons::LepTight;
+        out_.selBits->push_back(selBits);
+
+        if (pf)
+          out_.lepPfPt->push_back(pf->Pt());
+        else
+          out_.lepPfPt->push_back(0.);
+
+        // TODO
+        out_.chIso->push_back(0.);
+        out_.nhIso->push_back(0.);
+        out_.phoIso->push_back(0.);
+        out_.puIso->push_back(0.);
       }
-
-      out_.pdgId->push_back(13 * mu->Charge());
-      out_.iso->push_back(iso);
-      out_.tightId->push_back(muAId->At(iM)+2*muBId->At(iM));
-      if (pf)
-        out_.lepPfPt->push_back(pf->Pt());
-      else
-        out_.lepPfPt->push_back(0.);
-
-      // TODO
-      out_.chIso->push_back(0.);
-      out_.nhIso->push_back(0.);
-      out_.phoIso->push_back(0.);
-      out_.puIso->push_back(0.);
-
       ++iM;
     }
   }

--- a/Core/interface/BareLeptons.hpp
+++ b/Core/interface/BareLeptons.hpp
@@ -14,15 +14,15 @@ class BareLeptons : virtual public BareP4
         void setBranchAddresses(TTree*);
         virtual inline string name(){return "BareLeptons";};
         // ----
-        vector<int>   *pdgId;	
-        vector<float> *iso;	
-        vector<int>   *tightId;	
-        vector<float> *lepPfPt;
+        vector<int>      *pdgId;	
+        vector<float>    *iso;	
+        vector<unsigned> *tightId;	
+        vector<float>    *lepPfPt;
 
-        vector<float> *chIso;
-        vector<float> *nhIso;
-        vector<float> *phoIso;
-        vector<float> *puIso;
+        vector<float>    *chIso;
+        vector<float>    *nhIso;
+        vector<float>    *phoIso;
+        vector<float>    *puIso;
 };
 
 #endif

--- a/Core/interface/BareLeptons.hpp
+++ b/Core/interface/BareLeptons.hpp
@@ -7,16 +7,27 @@
 class BareLeptons : virtual public BareP4
 {
     public:
+        enum Selection {
+          LepVeto   = 1UL<<0,
+          LepFake   = 1UL<<1,
+          LepSoft   = 1UL<<2,
+          LepMedium = 1UL<<3,
+          LepTight  = 1UL<<4
+        };
+
         BareLeptons();
         ~BareLeptons();
         void clear();
         void defineBranches(TTree *t);
         void setBranchAddresses(TTree*);
         virtual inline string name(){return "BareLeptons";};
+
+        bool passSelection(unsigned idx, Selection sel) { return (selBits->at(idx) & sel) != 0; }
+
         // ----
         vector<int>      *pdgId;	
-        vector<float>    *iso;	
-        vector<unsigned> *tightId;	
+        vector<float>    *iso;
+        vector<unsigned> *selBits;
         vector<float>    *lepPfPt;
 
         vector<float>    *chIso;

--- a/Core/src/BareLeptons.cpp
+++ b/Core/src/BareLeptons.cpp
@@ -41,7 +41,7 @@ void BareLeptons::defineBranches(TTree*t){
     iso = new vector<float>;
     t->Branch("lepIso","vector<float>",&iso);
     //
-    tightId = new vector<int>;
+    tightId = new vector<unsigned>;
     t->Branch("lepTightId","vector<int>",&tightId);
     //
     lepPfPt = new vector<float>;
@@ -68,7 +68,7 @@ void BareLeptons::setBranchAddresses(TTree*t){
     t->SetBranchAddress("lepPdgId"	,&pdgId);
     iso = new vector<float>;
     t->SetBranchAddress("lepIso"	,&iso);
-    tightId = new vector<int>;
+    tightId = new vector<unsigned>;
     t->SetBranchAddress("lepTightId"	,&tightId);
     lepPfPt = new vector<float>;
     t->SetBranchAddress("lepPfPt"	,&lepPfPt);

--- a/Core/src/BareLeptons.cpp
+++ b/Core/src/BareLeptons.cpp
@@ -4,7 +4,7 @@ BareLeptons::BareLeptons():BareP4(){
     p4 = NULL;
     pdgId = NULL;
     iso = NULL;
-    tightId = NULL;
+    selBits = NULL;
     lepPfPt = NULL;
 
     //
@@ -22,7 +22,7 @@ void BareLeptons::clear(){
 
     pdgId -> clear();
     iso -> clear();
-    tightId ->clear();
+    selBits ->clear();
     lepPfPt->clear();    
 
     chIso->clear();
@@ -41,8 +41,8 @@ void BareLeptons::defineBranches(TTree*t){
     iso = new vector<float>;
     t->Branch("lepIso","vector<float>",&iso);
     //
-    tightId = new vector<unsigned>;
-    t->Branch("lepTightId","vector<int>",&tightId);
+    selBits = new vector<unsigned>;
+    t->Branch("lepSelBits","vector<unsigned>",&selBits);
     //
     lepPfPt = new vector<float>;
     t->Branch("lepPfPt","vector<float>",&lepPfPt);
@@ -68,8 +68,8 @@ void BareLeptons::setBranchAddresses(TTree*t){
     t->SetBranchAddress("lepPdgId"	,&pdgId);
     iso = new vector<float>;
     t->SetBranchAddress("lepIso"	,&iso);
-    tightId = new vector<unsigned>;
-    t->SetBranchAddress("lepTightId"	,&tightId);
+    selBits = new vector<unsigned>;
+    t->SetBranchAddress("lepSelBits"	,&selBits);
     lepPfPt = new vector<float>;
     t->SetBranchAddress("lepPfPt"	,&lepPfPt);
 

--- a/Nero/interface/NeroLeptons.hpp
+++ b/Nero/interface/NeroLeptons.hpp
@@ -21,7 +21,7 @@ class NeroLeptons : virtual public NeroCollection,
                 myLepton(){ chiso=-999; nhiso=-999; phoiso=-999; puiso=-999;}
                 float iso;
                 TLorentzVector p4;
-                int tightId;
+                unsigned selBits;
                 int pdgId;
                 float pfPt;
 

--- a/Nero/src/NeroLeptons.cpp
+++ b/Nero/src/NeroLeptons.cpp
@@ -55,7 +55,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
         l.pdgId = mu.charge()*13;
         l.iso = totiso;
         l.p4.SetPxPyPzE( mu.px(),mu.py(),mu.pz(),mu.energy());
-        l.tightId = int(mu.isTightMuon( * vtx_->GetPV() ))*2 + int(mu.isMediumMuon() );
+        l.tightId = unsigned(mu.isTightMuon( * vtx_->GetPV() ))*2 + unsigned(mu.isMediumMuon() );
         l.pfPt = mu.pfP4().pt();
 
         l.chiso  = chiso;
@@ -95,7 +95,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
 
         l.iso = chIso + nhIso + phoIso; 
         l.p4.SetPxPyPzE( el.px(),el.py(),el.pz(),el.energy());
-        l.tightId = int(isPassTight)*2  + int(isPassMedium);
+        l.tightId = unsigned(isPassTight)*2  + unsigned(isPassMedium);
         l.pfPt = 0.;
     
         l.chiso  = chIso;

--- a/Nero/src/NeroLeptons.cpp
+++ b/Nero/src/NeroLeptons.cpp
@@ -58,7 +58,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
         if ( totiso/mu.pt() > mMaxIso_mu ) continue;
 
         myLepton l;
-        l.pdgId = mu.charge()*13;
+        l.pdgId = -mu.charge()*13;
         l.iso = totiso;
         l.p4.SetPxPyPzE( mu.px(),mu.py(),mu.pz(),mu.energy());
         l.selBits = unsigned(mu.isTightMuon( * vtx_->GetPV() ))*LepTight + unsigned(mu.isMediumMuon() * LepMedium);
@@ -91,7 +91,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
         if (not isPassVeto ) continue;
 
         myLepton l;
-        l.pdgId = el.charge()*11;
+        l.pdgId = -el.charge()*11;
         //l.iso = el.ecalPFClusterIso() + el.hcalPFClusterIso(); //not working, use GEDIdTools or ValueMap
         
         float chIso = el.chargedHadronIso();

--- a/Nero/src/NeroLeptons.cpp
+++ b/Nero/src/NeroLeptons.cpp
@@ -55,7 +55,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
         l.pdgId = mu.charge()*13;
         l.iso = totiso;
         l.p4.SetPxPyPzE( mu.px(),mu.py(),mu.pz(),mu.energy());
-        l.tightId = unsigned(mu.isTightMuon( * vtx_->GetPV() ))*2 + unsigned(mu.isMediumMuon() );
+        l.selBits = unsigned(mu.isTightMuon( * vtx_->GetPV() ))*LepTight + unsigned(mu.isMediumMuon() * LepMedium);
         l.pfPt = mu.pfP4().pt();
 
         l.chiso  = chiso;
@@ -95,7 +95,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
 
         l.iso = chIso + nhIso + phoIso; 
         l.p4.SetPxPyPzE( el.px(),el.py(),el.pz(),el.energy());
-        l.tightId = unsigned(isPassTight)*2  + unsigned(isPassMedium);
+        l.selBits = unsigned(isPassTight)*LepTight  + unsigned(isPassMedium) * LepMedium;
         l.pfPt = 0.;
     
         l.chiso  = chIso;
@@ -117,7 +117,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
     {
         new ( (*p4)[p4->GetEntriesFast()]) TLorentzVector(l.p4);
         iso     -> push_back(l.iso);
-        tightId -> push_back(l.tightId);
+        selBits -> push_back(l.selBits);
         pdgId   -> push_back(l.pdgId);
         lepPfPt -> push_back(l.pfPt);
 


### PR DESCRIPTION
As long as the lepTightId variable is used as a pure bitmask, or as long as we only utilize the first 31 bits, whether it's an int or an unsigned does not matter. This is more about aesthetics, I guess. Have tested reading a file produced with the previous branch definition and saw no problem.