### PR TITLE
Adding some utility functions to P4 and other classes

### DIFF
--- a/Core/interface/BareAll.hpp
+++ b/Core/interface/BareAll.hpp
@@ -12,7 +12,8 @@ class BareAll : virtual public BareCollection
         void clear();
         void defineBranches(TTree*);
         virtual void setBranchAddresses(TTree*);
-        virtual inline string name(){ return "BareAll";}
+        virtual inline string name() { return "BareAll"; }
+        virtual inline unsigned size() const { return 1; }
 
         // -- variables
         int isRealData;

--- a/Core/interface/BareCollection.hpp
+++ b/Core/interface/BareCollection.hpp
@@ -21,9 +21,11 @@ class BareCollection
         BareCollection(){ extend_=false;}
         virtual ~BareCollection() {}
         virtual void clear() = 0;
+        virtual void init() {}
         virtual void defineBranches(TTree*) = 0 ;
         virtual void setBranchAddresses(TTree*) = 0;
         virtual string name() = 0;
+        virtual unsigned size() const { return 0; }
         virtual void compress(){}; // compress all double pointers
         
         inline void SetExtend(bool value=true){extend_=value;}

--- a/Core/interface/BareEvent.hpp
+++ b/Core/interface/BareEvent.hpp
@@ -11,7 +11,9 @@ class BareEvent : virtual public BareCollection
         void clear();
         void defineBranches(TTree*);
         void setBranchAddresses(TTree*);
-        virtual inline string name(){ return "BareEvent";}
+        virtual inline string name() { return "BareEvent"; }
+        virtual inline unsigned size() const { return 1; }
+    
 
         // -- variables
         int isRealData;

--- a/Core/interface/BareFatJets.hpp
+++ b/Core/interface/BareFatJets.hpp
@@ -11,29 +11,30 @@ class BareFatJets : virtual public BareP4
         BareFatJets();
         ~BareFatJets();
         void clear();
+        void init();
         void defineBranches(TTree *t);
         virtual void setBranchAddresses(TTree*);
-        virtual inline string name(){return "BareFatJets";};
+        virtual inline string name() { return "BareFatJets"; }
         virtual void compress();
 
         // -- variables
         //TClonesArray  *p4;
-        vector<float> *rawPt;
-        vector<int>   *flavour;
-        vector<float> *tau1;
-        vector<float> *tau2;
-        vector<float> *tau3;
+        vector<float> *rawPt{0};
+        vector<int>   *flavour{0};
+        vector<float> *tau1{0};
+        vector<float> *tau2{0};
+        vector<float> *tau3{0};
 
-        vector<float> *trimmedMass;
-        vector<float> *prunedMass;
-        vector<float> *filteredMass;
-        vector<float> *softdropMass;
+        vector<float> *trimmedMass{0};
+        vector<float> *prunedMass{0};
+        vector<float> *filteredMass{0};
+        vector<float> *softdropMass{0};
 
-        TClonesArray  *ak8_subjet;
-        vector<int>   *ak8jet_hasSubjet;
-        vector<float> *ak8subjet_btag;
+        TClonesArray  *ak8_subjet{0};
+        vector<int>   *ak8jet_hasSubjet{0};
+        vector<float> *ak8subjet_btag{0};
     
-        vector<float> *hbb;
+        vector<float> *hbb{0};
 
 };
 

--- a/Core/interface/BareJets.hpp
+++ b/Core/interface/BareJets.hpp
@@ -9,28 +9,29 @@ class BareJets : virtual public BareP4
     public:
         BareJets();
         ~BareJets();
+        void init();
         void clear();
         void defineBranches(TTree*);
         virtual void setBranchAddresses(TTree*);
-        virtual inline string name(){ return "BareJets";}
+        virtual inline string name() { return "BareJets"; }
 
         // -- variables
-        //TClonesArray  *p4;
-        vector<float> *rawPt;
-        vector<float> *bDiscr;
-        vector<float> *bDiscrLegacy;
-        vector<float> *puId;
-        vector<float> *unc;
-        vector<float> *qgl;
-        vector<int>   *flavour;
-        vector<int>   *matchedPartonPdgId;
-        vector<int>   *motherPdgId;
-        vector<int>   *grMotherPdgId;
-        vector<bool>  *mjId;
-        vector<bool>  *mjId_loose;
+        //TClonesArray  *p4{0};
+        vector<float> *rawPt{0};
+        vector<float> *bDiscr{0};
+        vector<float> *bDiscrLegacy{0};
+        vector<float> *puId{0};
+        vector<float> *unc{0};
+        vector<float> *qgl{0};
+        vector<int>   *flavour{0};
+        vector<int>   *matchedPartonPdgId{0};
+        vector<int>   *motherPdgId{0};
+        vector<int>   *grMotherPdgId{0};
+        vector<bool>  *mjId{0};
+        vector<bool>  *mjId_loose{0};
 
-        vector<float> *Q;
-        vector<float> *QnoPU;
+        vector<float> *Q{0};
+        vector<float> *QnoPU{0};
 
 };
 

--- a/Core/interface/BareLeptons.hpp
+++ b/Core/interface/BareLeptons.hpp
@@ -18,23 +18,24 @@ class BareLeptons : virtual public BareP4
 
         BareLeptons();
         ~BareLeptons();
+        void init();
         void clear();
         void defineBranches(TTree *t);
         void setBranchAddresses(TTree*);
-        virtual inline string name(){return "BareLeptons";};
+        virtual inline string name() { return "BareLeptons"; }
 
         bool inline passSelection(const unsigned &idx, const Selection &sel) const  { return (selBits->at(idx) & sel) != 0; }
 
         // ----
-        vector<int>      *pdgId;	
-        vector<float>    *iso;
-        vector<unsigned> *selBits;
-        vector<float>    *lepPfPt;
+        vector<int>      *pdgId{0};	
+        vector<float>    *iso{0};
+        vector<unsigned> *selBits{0};
+        vector<float>    *lepPfPt{0};
 
-        vector<float>    *chIso;
-        vector<float>    *nhIso;
-        vector<float>    *phoIso;
-        vector<float>    *puIso;
+        vector<float>    *chIso{0};
+        vector<float>    *nhIso{0};
+        vector<float>    *phoIso{0};
+        vector<float>    *puIso{0};
 };
 
 #endif

--- a/Core/interface/BareMet.hpp
+++ b/Core/interface/BareMet.hpp
@@ -10,25 +10,26 @@ class BareMet : virtual public BareP4
     public:
         BareMet();
         ~BareMet();
+        void init();
         void clear();
         void defineBranches(TTree *t);
         virtual void setBranchAddresses(TTree*) ;
-        virtual inline string name(){return "BareMet";};
+        virtual inline string name() { return "BareMet"; }
         virtual void compress();
 
         // -- variables
         //TClonesArray *p4;
-        vector<float> *ptJESUP;
-        vector<float> *ptJESDOWN;
+        vector<float> *ptJESUP{0};
+        vector<float> *ptJESDOWN{0};
 
         // Should not stay here, but in MC -> we will esculed it if run on onlyMc
-        TClonesArray *genP4;
+        TClonesArray *genP4{0};
 
-        TLorentzVector *metNoMu;
-        TLorentzVector *pfMet_e3p0;
-        TLorentzVector *metChargedHadron;
-        TLorentzVector *metNeutralHadron;
-        TLorentzVector *metNeutralEM;
+        TLorentzVector *metNoMu{0};
+        TLorentzVector *pfMet_e3p0{0};
+        TLorentzVector *metChargedHadron{0};
+        TLorentzVector *metNeutralHadron{0};
+        TLorentzVector *metNeutralEM{0};
   
         float caloMet_Pt;
         float caloMet_Phi;

--- a/Core/interface/BareMonteCarlo.hpp
+++ b/Core/interface/BareMonteCarlo.hpp
@@ -10,18 +10,19 @@ class BareMonteCarlo : virtual public BareP4
     public:
         BareMonteCarlo();
         ~BareMonteCarlo();
+        void init();
         void clear();
         void defineBranches(TTree *t);
         void setBranchAddresses(TTree*) ;
-        virtual inline string name(){return "BareMonteCarlo";};
+        virtual inline string name() { return "BareMonteCarlo"; }
         virtual void compress();
 
         // -- variables
-        //TClonesArray *p4; // gen particles
-        vector<int>  *pdgId;
+        //TClonesArray *p4{0}; // gen particles
+        vector<int>  *pdgId{0};
 
         // genjets
-        TClonesArray *jetP4;
+        TClonesArray *jetP4{0};
 
         //
         int puTrueInt;

--- a/Core/interface/BareP4.hpp
+++ b/Core/interface/BareP4.hpp
@@ -6,20 +6,33 @@
 class BareP4 : virtual public BareCollection
 {
     // just a container to identify all the objects that are based on p4
-    bool doMatch_;
+    bool doMatch_{false};
     public:
-        BareP4():BareCollection(){ p4=NULL;doMatch_=false;match=NULL;}
+        BareP4();
+        ~BareP4();
 
-        virtual inline string name(){ return "BareP4";}
+        virtual inline string name() { return "BareP4"; }
+        virtual inline unsigned size() const { if (p4) return p4->GetEntries(); else return 0; }
 
-        TClonesArray  *p4;
-        vector<int>   *match;
+        virtual inline TLorentzVector const& momentum(unsigned idx) const { return *static_cast<TLorentzVector*>((*p4)[idx]); }
+        virtual inline double px(unsigned idx) const { return static_cast<TLorentzVector*>((*p4)[idx])->Px(); }
+        virtual inline double py(unsigned idx) const { return static_cast<TLorentzVector*>((*p4)[idx])->Py(); }
+        virtual inline double pz(unsigned idx) const { return static_cast<TLorentzVector*>((*p4)[idx])->Pz(); }
+        virtual inline double energy(unsigned idx) const { return static_cast<TLorentzVector*>((*p4)[idx])->Energy(); }
+        virtual inline double pt(unsigned idx) const { return static_cast<TLorentzVector*>((*p4)[idx])->Pt(); }
+        virtual inline double eta(unsigned idx) const { return static_cast<TLorentzVector*>((*p4)[idx])->Eta(); }
+        virtual inline double phi(unsigned idx) const { return static_cast<TLorentzVector*>((*p4)[idx])->Phi(); }
+        virtual inline double mass(unsigned idx) const { return static_cast<TLorentzVector*>((*p4)[idx])->M(); }
+
+        TClonesArray  *p4{0};
+        vector<int>   *match{0};
 
         virtual bool isInit(){ return p4 != NULL;}
 
         inline void SetMatch(bool match=true){doMatch_=match;}
         inline bool doMatch() { return doMatch_;}
 
+        virtual void init();
         virtual void clear();
         void defineBranches(TTree *t,string prefix="");
         void setBranchAddresses(TTree*t,string prefix ="");

--- a/Core/interface/BarePhotons.hpp
+++ b/Core/interface/BarePhotons.hpp
@@ -10,27 +10,28 @@ class BarePhotons : virtual public BareP4
     public:
         BarePhotons();
         ~BarePhotons();
+        void init();
         void clear();
         void defineBranches(TTree *t);
         void setBranchAddresses(TTree*) ;
-        virtual inline string name(){return "BarePhotons";};
+        virtual inline string name() { return "BarePhotons"; }
 
         // -- variables
-        //TClonesArray *p4;
-        vector<float> *sieie;
-        vector<float> *iso;
-        vector<int> *looseid;
-        vector<int> *tightid;
-        vector<int> *mediumid;
+        //TClonesArray *p4{0};
+        vector<float> *sieie{0};
+        vector<float> *iso{0};
+        vector<int> *looseid{0};
+        vector<int> *tightid{0};
+        vector<int> *mediumid{0};
 
-        vector<float> *chIso;
-        vector<float> *chIsoRC;
-        vector<float> *nhIso;
-        vector<float> *nhIsoRC;
-        vector<float> *phoIso;
-        vector<float> *phoIsoRC;
-        vector<float> *puIso;
-        vector<float> *puIsoRC;
+        vector<float> *chIso{0};
+        vector<float> *chIsoRC{0};
+        vector<float> *nhIso{0};
+        vector<float> *nhIsoRC{0};
+        vector<float> *phoIso{0};
+        vector<float> *phoIsoRC{0};
+        vector<float> *puIso{0};
+        vector<float> *puIsoRC{0};
 };
 
 #endif

--- a/Core/interface/BareTaus.hpp
+++ b/Core/interface/BareTaus.hpp
@@ -9,26 +9,27 @@ class BareTaus : virtual public BareP4
     public:
         BareTaus();
         ~BareTaus();
+        void init();
         void clear();
         void defineBranches(TTree *t);
         void setBranchAddresses(TTree*) ;
-        virtual inline string name(){return "BareTaus";};
+        virtual inline string name() { return "BareTaus"; }
 
         // --  members
-        //TClonesArray    *p4;
-        vector<float>   *id ; 
-        vector<int>     *Q ; // charge
-        vector<float>   *M ; // mass
-        vector<float>   *iso ;
+        //TClonesArray    *p4{0};
+        vector<float>   *id{0}; 
+        vector<int>     *Q{0}; // charge
+        vector<float>   *M{0}; // mass
+        vector<float>   *iso{0};
 
         // EXTENDED VARIABLES
-        vector<float>   *chargedIsoPtSum;
-        vector<float>   *neutralIsoPtSum;
-        vector<float>   *isoDeltaBetaCorr;
-        vector<int>   *againstEleLoose;
-        vector<int>   *againstEleMedium;
-        vector<int>   *againstMuLoose;
-        vector<int>   *againstMuTight;
+        vector<float>   *chargedIsoPtSum{0};
+        vector<float>   *neutralIsoPtSum{0};
+        vector<float>   *isoDeltaBetaCorr{0};
+        vector<int>   *againstEleLoose{0};
+        vector<int>   *againstEleMedium{0};
+        vector<int>   *againstMuLoose{0};
+        vector<int>   *againstMuTight{0};
 };
 
 #endif

--- a/Core/interface/BareTrigger.hpp
+++ b/Core/interface/BareTrigger.hpp
@@ -10,22 +10,25 @@ class BareTrigger: virtual public BareCollection
     public:
         BareTrigger();
         ~BareTrigger();
+        void init();
         void clear();
         void defineBranches(TTree*);
         virtual void setBranchAddresses(TTree*);
-        virtual inline string name(){ return "BareTrigger";}
+        virtual inline string name() { return "BareTrigger"; }
+        virtual inline unsigned size() const { return triggerNames->size(); }
 
         //variables
-        vector<int>  *triggerFired; // bool vector are not supported in TTree
-        vector<float>  *triggerPrescale; // bool vector are not supported in TTree
+        vector<int>  *triggerFired{0}; // bool vector are not supported in TTree
+        vector<float>  *triggerPrescale{0}; // bool vector are not supported in TTree
 
         //configuration
+        // new'ed in the constructor
         vector<string> *triggerNames;
 
-        vector<int>  *triggerLeps;
-        vector<int>  *triggerJets;
-        vector<int>  *triggerTaus;
-        vector<int>  *triggerPhotons;
+        vector<int>  *triggerLeps{0};
+        vector<int>  *triggerJets{0};
+        vector<int>  *triggerTaus{0};
+        vector<int>  *triggerPhotons{0};
 
 };
 

--- a/Core/interface/BareVertex.hpp
+++ b/Core/interface/BareVertex.hpp
@@ -12,7 +12,8 @@ class BareVertex : virtual public BareCollection
         void clear();
         void defineBranches(TTree *t);
         virtual void setBranchAddresses(TTree*);
-        virtual inline string name(){return "BareVertex";};
+        virtual inline string name() { return "BareVertex"; }
+        virtual inline unsigned size() const { return npv; }
 
         int npv;
 

--- a/Core/src/BareAll.cpp
+++ b/Core/src/BareAll.cpp
@@ -26,12 +26,18 @@ void BareAll::defineBranches(TTree *t){
 
 void BareAll::setBranchAddresses(TTree *t){
     //
-    t->SetBranchAddress("isRealData"  ,&isRealData   );
-    t->SetBranchAddress("runNum"      ,&runNum       );
-    t->SetBranchAddress("lumiNum"     ,&lumiNum      );
-    t->SetBranchAddress("eventNum"    ,&eventNum     );
-    t->SetBranchAddress("mcWeight"    ,&mcWeight     );
-    t->SetBranchAddress("puTrueInt"     ,&puTrueInt  );
+    if (t->GetBranchStatus("isRealData"))
+        t->SetBranchAddress("isRealData"  ,&isRealData   );
+    if (t->GetBranchStatus("runNum"))
+        t->SetBranchAddress("runNum"      ,&runNum       );
+    if (t->GetBranchStatus("lumiNum"))
+        t->SetBranchAddress("lumiNum"     ,&lumiNum      );
+    if (t->GetBranchStatus("eventNum"))
+        t->SetBranchAddress("eventNum"    ,&eventNum     );
+    if (t->GetBranchStatus("mcWeight"))
+        t->SetBranchAddress("mcWeight"    ,&mcWeight     );
+    if (t->GetBranchStatus("puTrueInt"))
+        t->SetBranchAddress("puTrueInt"     ,&puTrueInt  );
 }
 
 // Local Variables:

--- a/Core/src/BareEvent.cpp
+++ b/Core/src/BareEvent.cpp
@@ -35,16 +35,24 @@ void BareEvent::defineBranches(TTree *t){
 
 void BareEvent::setBranchAddresses(TTree *t){
     //
-    t->SetBranchAddress("isRealData"  ,&isRealData  );
-    t->SetBranchAddress("runNum"      ,&runNum      );
-    t->SetBranchAddress("lumiNum"     ,&lumiNum     );
-    t->SetBranchAddress("eventNum"    ,&eventNum    );
-    t->SetBranchAddress("rho"    	,&rho         );
+    if (t->GetBranchStatus("isRealData"))
+        t->SetBranchAddress("isRealData"  ,&isRealData  );
+    if (t->GetBranchStatus("runNum"))
+        t->SetBranchAddress("runNum"      ,&runNum      );
+    if (t->GetBranchStatus("lumiNum"))
+        t->SetBranchAddress("lumiNum"     ,&lumiNum     );
+    if (t->GetBranchStatus("eventNum"))
+        t->SetBranchAddress("eventNum"    ,&eventNum    );
+    if (t->GetBranchStatus("rho"))
+        t->SetBranchAddress("rho"    	,&rho         );
     if (IsExtend() )
     {
-        t->SetBranchAddress("originalRun"      ,&originalRun      );
-        t->SetBranchAddress("originalLumi"      ,&originalLumi      );
-        t->SetBranchAddress("originalEvent"      ,&originalEvent      );
+        if (t->GetBranchStatus("originalRun"))
+            t->SetBranchAddress("originalRun"      ,&originalRun      );
+        if (t->GetBranchStatus("originalLumi"))
+            t->SetBranchAddress("originalLumi"      ,&originalLumi      );
+        if (t->GetBranchStatus("originalEvent"))
+            t->SetBranchAddress("originalEvent"      ,&originalEvent      );
     }
 }
 

--- a/Core/src/BareFatJets.cpp
+++ b/Core/src/BareFatJets.cpp
@@ -3,24 +3,54 @@
 
 
 BareFatJets::BareFatJets(): BareP4(){
-    p4 = NULL;
-    rawPt = NULL;
-    flavour = NULL;
-    tau1 = NULL;
-    tau2 = NULL;
-    tau3 = NULL;
-    trimmedMass = NULL;
-    prunedMass = NULL;
-    filteredMass = NULL;
-    softdropMass = NULL;
-    ak8_subjet = NULL;
-    ak8jet_hasSubjet = NULL;
-    ak8subjet_btag = NULL;
-    hbb = NULL;
-
 }
 
 BareFatJets::~BareFatJets(){
+    delete rawPt;
+    delete flavour;
+    delete tau1;
+    delete tau2;
+    delete tau3;
+    delete trimmedMass;
+    delete prunedMass;
+    delete filteredMass;
+    delete softdropMass;
+    delete ak8_subjet;
+    delete ak8jet_hasSubjet;
+    delete ak8subjet_btag;
+}
+
+void BareFatJets::init(){
+    BareP4::init();
+
+    if (!rawPt)
+        rawPt = new vector<float>;
+
+    if (!flavour)
+        flavour = new vector<int>;
+    //
+    if (!tau1)
+        tau1 = new vector<float>;
+    if (!tau2)
+        tau2 = new vector<float>;
+    if (!tau3)
+        tau3 = new vector<float>;
+
+    if (!trimmedMass)
+        trimmedMass = new vector<float>;
+    if (!prunedMass)
+        prunedMass = new vector<float>;
+    if (!filteredMass)
+        filteredMass = new vector<float>;
+    if (!softdropMass)
+        softdropMass = new vector<float>;
+
+    if (!ak8_subjet)
+        ak8_subjet = new TClonesArray("TLorentzVector", 20);
+    if (!ak8jet_hasSubjet)
+        ak8jet_hasSubjet = new vector<int>;
+    if (!ak8subjet_btag)
+        ak8subjet_btag = new vector<float>;
 }
 
 void BareFatJets::clear(){
@@ -43,81 +73,63 @@ void BareFatJets::clear(){
 }
 
 void BareFatJets::defineBranches(TTree *t){
-    //
+    // init() called by BareP4
     BareP4::defineBranches(t, "fatjet" );
     //
-    rawPt = new vector<float>;
     t->Branch("fatjetRawPt","vector<float>",&rawPt);
     // -- Jet Flavour by PAT
-    flavour = new vector<int>;
     t->Branch("fatjetFlavour","vector<int>",&flavour);
     //
-    tau1 = new vector<float>;
     t->Branch("fatjetTau1","vector<float>",&tau1);
-    tau2 = new vector<float>;
     t->Branch("fatjetTau2","vector<float>",&tau2);
-    tau3 = new vector<float>;
     t->Branch("fatjetTau3","vector<float>",&tau3);
 
     //
-    trimmedMass = new vector<float>;
     t->Branch("fatjetTrimmedMass","vector<float>",&trimmedMass);
-    prunedMass = new vector<float>;
     t->Branch("fatjetPrunedMass","vector<float>",&prunedMass);
-    filteredMass = new vector<float>;
     t->Branch("fatjetFilteredMass","vector<float>",&filteredMass);
-    softdropMass = new vector<float>;
     t->Branch("fatjetSoftdropMass","vector<float>",&softdropMass);
 
-    ak8_subjet = new TClonesArray("TLorentzVector", 20);
     t->Branch("ak8_subjet","TClonesArray", &ak8_subjet, 128000, 0);
-    ak8jet_hasSubjet =  new vector<int>;
     t->Branch("ak8jet_hasSubjet","vector<int>",&ak8jet_hasSubjet);
-    ak8subjet_btag =  new vector<float>;
     t->Branch("ak8subjet_btag","vector<float>",&ak8subjet_btag);
 
-    hbb =  new vector<float>;
     t->Branch("fatjetHbb","vector<float>",&hbb);
-
 }
 
 void BareFatJets::setBranchAddresses(TTree *t){
-    //
+    // init() called by BareP4
     BareP4::setBranchAddresses(t,"fatjet");
 
-    rawPt = new vector<float>;
-    // -- Jet Flavour by PAT
-    flavour = new vector<int>;
-    //
-    tau1 = new vector<float>;
-    tau2 = new vector<float>;
-    tau3 = new vector<float>;
+    if (t->GetBranchStatus("fatjetRawPt"))
+        t->SetBranchAddress("fatjetRawPt"	,&rawPt);
+    if (t->GetBranchStatus("fatjetFlavour"))
+        t->SetBranchAddress("fatjetFlavour" ,&flavour);
+    if (t->GetBranchStatus("fatjetTau1"))
+        t->SetBranchAddress("fatjetTau1"	,&tau1);
+    if (t->GetBranchStatus("fatjetTau2"))
+        t->SetBranchAddress("fatjetTau2"	,&tau2);
+    if (t->GetBranchStatus("fatjetTau3"))
+        t->SetBranchAddress("fatjetTau3"	,&tau3);
 
-    trimmedMass = new vector<float>;
-    prunedMass = new vector<float>;
-    filteredMass = new vector<float>;
-    softdropMass = new vector<float>;
+    if (t->GetBranchStatus("fatjetTrimmedMass"))
+        t->SetBranchAddress("fatjetTrimmedMass"	,&trimmedMass);
+    if (t->GetBranchStatus("fatjetPrunedMass"))
+        t->SetBranchAddress("fatjetPrunedMass"	,&prunedMass);
+    if (t->GetBranchStatus("fatjetFilteredMass"))
+        t->SetBranchAddress("fatjetFilteredMass"	,&filteredMass);
+    if (t->GetBranchStatus("fatjetSoftdropMass"))
+        t->SetBranchAddress("fatjetSoftdropMass"	,&softdropMass);
 
-    t->SetBranchAddress("fatjetRawPt"	,&rawPt);
-    t->SetBranchAddress("fatjetFlavour" ,&flavour);
-    t->SetBranchAddress("fatjetTau1"	,&tau1);
-    t->SetBranchAddress("fatjetTau2"	,&tau2);
-    t->SetBranchAddress("fatjetTau3"	,&tau3);
+    if (t->GetBranchStatus("ak8_subjet"))
+        t->SetBranchAddress("ak8_subjet"	,&ak8_subjet);
+    if (t->GetBranchStatus("ak8jet_hasSubjet"))
+        t->SetBranchAddress("ak8jet_hasSubjet",&ak8jet_hasSubjet);
+    if (t->GetBranchStatus("ak8subjet_btag"))
+        t->SetBranchAddress("ak8subjet_btag",&ak8subjet_btag);
 
-    t->SetBranchAddress("fatjetTrimmedMass"	,&trimmedMass);
-    t->SetBranchAddress("fatjetPrunedMass"	,&prunedMass);
-    t->SetBranchAddress("fatjetFilteredMass"	,&filteredMass);
-    t->SetBranchAddress("fatjetSoftdropMass"	,&softdropMass);
-
-    ak8_subjet = new TClonesArray("TLorentzVector", 20);
-    t->SetBranchAddress("ak8_subjet"	,&ak8_subjet);
-    ak8jet_hasSubjet =  new vector<int>;
-    t->SetBranchAddress("ak8jet_hasSubjet",&ak8jet_hasSubjet);
-    ak8subjet_btag =  new vector<float>;
-    t->SetBranchAddress("ak8subjet_btag",&ak8subjet_btag);
-
-    hbb =  new vector<float>;
-    t->SetBranchAddress("fatjetHbb",&hbb);
+    if (t->GetBranchStatus("fatjetHbb"))
+        t->SetBranchAddress("fatjetHbb",&hbb);
 }
 void BareFatJets::compress(){
     BareP4::compress();

--- a/Core/src/BareJets.cpp
+++ b/Core/src/BareJets.cpp
@@ -1,26 +1,66 @@
 #include "NeroProducer/Core/interface/BareJets.hpp"
 
 BareJets::BareJets(): BareP4(){
-    p4      = NULL;
-    rawPt   = NULL;
-    bDiscr = NULL;
-    bDiscrLegacy = NULL;
-    puId    = NULL;
-    unc     = NULL;
-    qgl     = NULL;
-    flavour = NULL;
-    matchedPartonPdgId = NULL;
-    motherPdgId = NULL;
-    grMotherPdgId = NULL;
-    mjId    = NULL;
-    mjId_loose  = NULL;
-    //
-    Q=NULL;
-    QnoPU=NULL;
 }
 
-BareJets::~BareJets(){}
+BareJets::~BareJets(){
+    delete rawPt;
+    delete bDiscr;
+    delete bDiscrLegacy;
+    delete puId;
+    delete unc;
+    delete qgl;
+    delete flavour;
+    delete matchedPartonPdgId;
+    delete motherPdgId;
+    delete grMotherPdgId;
+    delete mjId;
+    delete mjId_loose;
+    delete Q;
+    delete QnoPU;
+}
 
+void BareJets::init(){
+    BareP4::init();
+
+    if (!rawPt)
+        rawPt = new vector<float>;
+    //
+    if (!bDiscr)
+        bDiscr = new vector<float>;
+    //
+    if (!bDiscrLegacy)
+        bDiscrLegacy = new vector<float>;
+    //	
+    if (!puId)
+        puId = new vector<float>;
+    // -- JES uncertainty
+    if (!unc)
+        unc = new vector<float>;
+    // --QGL
+    if (!qgl)
+        qgl = new vector<float>;
+    // -- Jet Flavour by PAT
+    if (!flavour)
+        flavour = new vector<int>;
+
+    if (!matchedPartonPdgId)
+        matchedPartonPdgId = new vector<int>;
+    if (!motherPdgId)
+        motherPdgId = new vector<int>;
+    if (!grMotherPdgId)
+        grMotherPdgId = new vector<int>;
+
+    if (!mjId)
+        mjId = new vector<bool>;
+    if (!mjId_loose)
+        mjId_loose = new vector<bool>;
+
+    if (!Q)
+        Q = new vector<float>;
+    if (!QnoPU)
+        QnoPU = new vector<float>;
+}
 
 void BareJets::clear(){
     // This function clear all the internal storage and init it to an arbitrary value
@@ -46,87 +86,74 @@ void BareJets::clear(){
 
 void BareJets::defineBranches(TTree *t){
     //
-    //p4 = new TClonesArray("TLorentzVector", 20);
     //t->Branch("jetP4","TClonesArray", &p4, 128000, 0);
     BareP4::defineBranches(t, "jet" );
     //
-    rawPt = new vector<float>;
     t->Branch("jetRawPt","vector<float>",&rawPt);
     //
-    bDiscr = new vector<float>;
     t->Branch("jetBdiscr","vector<float>",&bDiscr);
     //
-    bDiscrLegacy = new vector<float>;
     t->Branch("jetBdiscrLegacy","vector<float>",&bDiscrLegacy);
     //	
-    puId = new vector<float>;
     t->Branch("jetPuId","vector<float>",&puId);
     // -- JES uncertainty
-    unc = new vector<float>;
     t->Branch("jetUnc","vector<float>",&unc);
     // --QGL
-    qgl = new vector<float>;
     t->Branch("jetQGL","vector<float>",&qgl);
     // -- Jet Flavour by PAT
-    flavour = new vector<int>;
     t->Branch("jetFlavour","vector<int>",&flavour);
 
-    matchedPartonPdgId = new vector<int>;
     t->Branch("jetMatchedPartonPdgId","vector<int>",&matchedPartonPdgId);
     
-    motherPdgId = new vector<int>;
     t->Branch("jetMotherPdgId","vector<int>",&motherPdgId);
     
-    grMotherPdgId = new vector<int>;
     t->Branch("jetGrMotherPdgId","vector<int>",&grMotherPdgId);
     
-    mjId = new vector<bool>;
     t->Branch("jetMonojetId","vector<bool>",&mjId);
 
-    mjId_loose = new vector<bool>;
     t->Branch("jetMonojetIdLoose","vector<bool>",&mjId_loose);
 
-    Q = new vector<float>;
     t->Branch("jetQ","vector<float>",&Q);
-    QnoPU = new vector<float>;
+
     t->Branch("jetQnoPU","vector<float>",&QnoPU);
 }
 
-void BareJets::setBranchAddresses(TTree*t)
+void BareJets::setBranchAddresses(TTree* t)
 {
     BareP4::setBranchAddresses(t,"jet");
     //p4 = new TClonesArray("TLorentzVector", 20);
-    //t->SetBranchAddress("jetP4"	, &p4	);
-    rawPt = new vector<float>;
-    t->SetBranchAddress("jetRawPt"	,&rawPt);
-    bDiscr = new vector<float>;
-    t->SetBranchAddress("jetBdiscr"	,&bDiscr);
-    bDiscrLegacy = new vector<float>;
-    t->SetBranchAddress("jetBdiscrLegacy"	,&bDiscrLegacy);
-    puId = new vector<float>;
-    t->SetBranchAddress("jetPuId"	,&puId);
-    unc = new vector<float>;
-    t->SetBranchAddress("jetUnc"	,&unc);
-    qgl = new vector<float>;
-    t->SetBranchAddress("jetQGL"	,&qgl);
-    flavour = new vector<int>;
-    t->SetBranchAddress("jetFlavour"	,&flavour);
-    matchedPartonPdgId = new vector<int>;
-    t->SetBranchAddress("jetMatchedPartonPdgId", &matchedPartonPdgId);
-    motherPdgId = new vector<int>;
-    t->SetBranchAddress("jetMotherPdgId", &motherPdgId);
-    grMotherPdgId = new vector<int>;
-    t->SetBranchAddress("jetGrMotherPdgId", &grMotherPdgId);
-    mjId= new vector<bool>;
-    t->SetBranchAddress("jetMonojetId", &mjId);
-    mjId_loose= new vector<bool>;
-    t->SetBranchAddress("jetMonojetIdLoose", &mjId_loose);
+    //if (t->GetBranchStatus("jetP4"))
+        //t->SetBranchAddress("jetP4"	, &p4	);
+    if (t->GetBranchStatus("jetRawPt"))
+        t->SetBranchAddress("jetRawPt"	,&rawPt);
+    if (t->GetBranchStatus("jetBdiscr"))
+        t->SetBranchAddress("jetBdiscr"	,&bDiscr);
+    if (t->GetBranchStatus("jetBdiscrLegacy"))
+        t->SetBranchAddress("jetBdiscrLegacy"	,&bDiscrLegacy);
+    if (t->GetBranchStatus("jetPuId"))
+        t->SetBranchAddress("jetPuId"	,&puId);
+    if (t->GetBranchStatus("jetUnc"))
+        t->SetBranchAddress("jetUnc"	,&unc);
+    if (t->GetBranchStatus("jetQGL"))
+        t->SetBranchAddress("jetQGL"	,&qgl);
+    if (t->GetBranchStatus("jetFlavour"))
+        t->SetBranchAddress("jetFlavour"	,&flavour);
+    if (t->GetBranchStatus("jetMatchedPartonPdgId"))
+        t->SetBranchAddress("jetMatchedPartonPdgId", &matchedPartonPdgId);
+    if (t->GetBranchStatus("jetMotherPdgId"))
+        t->SetBranchAddress("jetMotherPdgId", &motherPdgId);
+    if (t->GetBranchStatus("jetGrMotherPdgId"))
+        t->SetBranchAddress("jetGrMotherPdgId", &grMotherPdgId);
+    if (t->GetBranchStatus("jetMonojetId"))
+        t->SetBranchAddress("jetMonojetId", &mjId);
+    if (t->GetBranchStatus("jetMonojetIdLoose"))
+        t->SetBranchAddress("jetMonojetIdLoose", &mjId_loose);
 
     // ---
-    Q = new vector<float>;
-    t->SetBranchAddress("jetQ",&Q);
-    QnoPU = new vector<float>;
-    t->SetBranchAddress("jetQnoPU",&QnoPU);
+    if (t->GetBranchStatus("jetQ"))
+        t->SetBranchAddress("jetQ",&Q);
+    if (t->GetBranchStatus("jetQnoPU"))
+        t->SetBranchAddress("jetQnoPU",&QnoPU);
 
 }
 // Local Variables:

--- a/Core/src/BareLeptons.cpp
+++ b/Core/src/BareLeptons.cpp
@@ -1,20 +1,42 @@
 #include "NeroProducer/Core/interface/BareLeptons.hpp"
 
 BareLeptons::BareLeptons():BareP4(){
-    p4 = NULL;
-    pdgId = NULL;
-    iso = NULL;
-    selBits = NULL;
-    lepPfPt = NULL;
-
-    //
-    chIso=NULL;
-    nhIso=NULL;
-    phoIso=NULL;
-    puIso=NULL;
 }
 
 BareLeptons::~BareLeptons(){
+    delete pdgId;
+    delete iso;
+    delete selBits;
+    delete lepPfPt;
+    delete chIso;
+    delete nhIso;
+    delete phoIso;
+    delete puIso;
+}
+
+void BareLeptons::init(){
+    BareP4::init();
+
+    if (!pdgId)
+        pdgId = new vector<int>;
+    //
+    if (!iso)
+        iso = new vector<float>;
+    //
+    if (!selBits)
+        selBits = new vector<unsigned>;
+    //
+    if (!lepPfPt)
+        lepPfPt = new vector<float>;
+    // 
+    if (!chIso)
+        chIso=new vector<float>;
+    if (!nhIso)
+        nhIso=new vector<float>;
+    if (!phoIso)
+        phoIso=new vector<float>;
+    if (!puIso)
+        puIso=new vector<float>;
 }
 
 void BareLeptons::clear(){
@@ -35,53 +57,42 @@ void BareLeptons::defineBranches(TTree*t){
     //
     BareP4::defineBranches(t, "lep" );
     //
-    pdgId = new vector<int>;
     t->Branch("lepPdgId","vector<int>",&pdgId);
     //
-    iso = new vector<float>;
     t->Branch("lepIso","vector<float>",&iso);
     //
-    selBits = new vector<unsigned>;
     t->Branch("lepSelBits","vector<unsigned>",&selBits);
     //
-    lepPfPt = new vector<float>;
     t->Branch("lepPfPt","vector<float>",&lepPfPt);
 
     // 
-    chIso=new vector<float>;
     t->Branch("lepChIso","vector<float>",&chIso);
-    nhIso=new vector<float>;
     t->Branch("lepNhIso","vector<float>",&nhIso);
-    phoIso=new vector<float>;
     t->Branch("lepPhoIso","vector<float>",&phoIso);
-    puIso=new vector<float>;
     t->Branch("lepPuIso","vector<float>",&puIso);
-    
-
 }
 
 void BareLeptons::setBranchAddresses(TTree*t){
 
     BareP4::setBranchAddresses(t,"lep");
 
-    pdgId = new vector<int>;
-    t->SetBranchAddress("lepPdgId"	,&pdgId);
-    iso = new vector<float>;
-    t->SetBranchAddress("lepIso"	,&iso);
-    selBits = new vector<unsigned>;
-    t->SetBranchAddress("lepSelBits"	,&selBits);
-    lepPfPt = new vector<float>;
-    t->SetBranchAddress("lepPfPt"	,&lepPfPt);
+    if (t->GetBranchStatus("lepPdgId"))
+        t->SetBranchAddress("lepPdgId"	,&pdgId);
+    if (t->GetBranchStatus("lepIso"))
+        t->SetBranchAddress("lepIso"	,&iso);
+    if (t->GetBranchStatus("lepSelBits"))
+        t->SetBranchAddress("lepSelBits"	,&selBits);
+    if (t->GetBranchStatus("lepPfPt"))
+        t->SetBranchAddress("lepPfPt"	,&lepPfPt);
 
-    chIso=new vector<float>;
-    t->SetBranchAddress("lepChIso",&chIso);
-    nhIso=new vector<float>;
-    t->SetBranchAddress("lepNhIso",&nhIso);
-    phoIso=new vector<float>;
-    t->SetBranchAddress("lepPhoIso",&phoIso);
-    puIso=new vector<float>;
-    t->SetBranchAddress("lepPuIso",&puIso);
-
+    if (t->GetBranchStatus("lepChIso"))
+        t->SetBranchAddress("lepChIso",&chIso);
+    if (t->GetBranchStatus("lepNhIso"))
+        t->SetBranchAddress("lepNhIso",&nhIso);
+    if (t->GetBranchStatus("lepPhoIso"))
+        t->SetBranchAddress("lepPhoIso",&phoIso);
+    if (t->GetBranchStatus("lepPuIso"))
+        t->SetBranchAddress("lepPuIso",&puIso);
 }
 
 // Local Variables:

--- a/Core/src/BareMet.cpp
+++ b/Core/src/BareMet.cpp
@@ -3,23 +3,49 @@
 
 
 BareMet::BareMet() : BareP4() {
-    p4 = NULL;
-    ptJESUP = NULL;
-    ptJESDOWN = NULL;
-    genP4 = NULL;
-
-    caloMet_Pt = 0.0;
-    caloMet_Phi = 0.0;
-    caloMet_SumEt = 0.0;
-
-    metNoMu = NULL;
-    pfMet_e3p0 = NULL;
-    metChargedHadron = NULL;
-    metNeutralHadron = NULL;
-    metNeutralEM = NULL;
 }
 
 BareMet::~BareMet(){
+    delete ptJESUP;
+    delete ptJESDOWN;
+    delete genP4;
+    delete metNoMu;
+    delete pfMet_e3p0;
+    delete metChargedHadron;
+    delete metNeutralHadron;
+    delete metNeutralEM;
+}
+
+void BareMet::init(){
+    BareP4::init();
+
+    if (!ptJESUP)
+        ptJESUP = new vector<float>;
+    //
+    if (!ptJESDOWN)
+        ptJESDOWN = new vector<float>;
+    //	
+    if (!genP4)
+        genP4 = new TClonesArray("TLorentzVector", 20);
+    //
+
+    if ( IsExtend() )
+    {
+        if (!metNoMu)
+            metNoMu = new TLorentzVector;
+        //
+        if (!pfMet_e3p0)
+            pfMet_e3p0 = new TLorentzVector;
+        //
+        if (!metChargedHadron)
+            metChargedHadron = new TLorentzVector;
+        //
+        if (!metNeutralHadron)
+            metNeutralHadron = new TLorentzVector;
+        //
+        if (!metNeutralEM)
+            metNeutralEM = new TLorentzVector;
+    }
 }
 
 void BareMet::clear(){
@@ -44,31 +70,23 @@ void BareMet::defineBranches(TTree *t){
     //
     BareP4::defineBranches(t, "met" );
     //
-    ptJESUP = new vector<float>;
     t->Branch("metPtJESUP","vector<float>",&ptJESUP);
     //
-    ptJESDOWN = new vector<float>;
     t->Branch("metPtJESDOWN","vector<float>",&ptJESDOWN);
     //	
-    genP4 = new TClonesArray("TLorentzVector", 20);
     t->Branch("metP4_GEN","TClonesArray", &p4, 128000, 0);
     //
 
     if ( IsExtend() )
     {
-        metNoMu = new TLorentzVector;
         t->Branch("metNoMu","TLorentzVector",&metNoMu);
         //
-        pfMet_e3p0 = new TLorentzVector;
         t->Branch("pfMet_e3p0","TLorentzVector",&pfMet_e3p0);
         //
-        metChargedHadron = new TLorentzVector;
         t->Branch("metChargedHadron","TLorentzVector",&metChargedHadron);
         //
-        metNeutralHadron = new TLorentzVector;
         t->Branch("metNeutralHadron","TLorentzVector",&metNeutralHadron);
         //
-        metNeutralEM = new TLorentzVector;
         t->Branch("metNeutralEM","TLorentzVector",&metNeutralEM);
         // calo Met
         t->Branch("caloMet_Pt",&caloMet_Pt,"caloMet_Pt/F");
@@ -82,30 +100,32 @@ void BareMet::setBranchAddresses(TTree *t){
 
     BareP4::setBranchAddresses(t,"met");
 
-    ptJESUP = new vector<float>;
-    t->SetBranchAddress("metPtJESUP"	,&ptJESUP);
-    ptJESDOWN = new vector<float>;
-    t->SetBranchAddress("metPtJESDOWN",&ptJESDOWN);
-    genP4 = new TClonesArray("TLorentzVector", 20);
-    t->SetBranchAddress("metP4_GEN"	, &genP4 );
-    
+    if (t->GetBranchStatus("metPtJESUP"))
+        t->SetBranchAddress("metPtJESUP"	,&ptJESUP);
+    if (t->GetBranchStatus("metPtJESDOWN"))
+        t->SetBranchAddress("metPtJESDOWN",&ptJESDOWN);
+    if (t->GetBranchStatus("metP4_GEN"))
+        t->SetBranchAddress("metP4_GEN"	, &genP4 );
 
     if ( IsExtend() ) 
     {
-        metNoMu = new TLorentzVector;
-        t->SetBranchAddress("metNoMu", &metNoMu);
-        pfMet_e3p0 = new TLorentzVector;
-        t->SetBranchAddress("pfMet_e3p0", &pfMet_e3p0);
-        metChargedHadron = new TLorentzVector;
-        t->SetBranchAddress("metChargedHadron", &metChargedHadron);
-        metNeutralHadron = new TLorentzVector;
-        t->SetBranchAddress("metNeutralHadron", &metNeutralHadron);
-        metNeutralEM = new TLorentzVector;
-        t->SetBranchAddress("metNeutralEM", &metNeutralEM);
-        // calo met
-        t->SetBranchAddress("caloMet_Pt", &caloMet_Pt);
-        t->SetBranchAddress("caloMet_Phi", &caloMet_Phi);
-        t->SetBranchAddress("caloMet_SumEt", &caloMet_SumEt);
+        if (t->GetBranchStatus("metNoMu"))
+            t->SetBranchAddress("metNoMu", &metNoMu);
+        if (t->GetBranchStatus("pfMet_e3p0"))
+            t->SetBranchAddress("pfMet_e3p0", &pfMet_e3p0);
+        if (t->GetBranchStatus("metChargedHadron"))
+            t->SetBranchAddress("metChargedHadron", &metChargedHadron);
+        if (t->GetBranchStatus("metNeutralHadron"))
+            t->SetBranchAddress("metNeutralHadron", &metNeutralHadron);
+        if (t->GetBranchStatus("metNeutralEM"))
+            t->SetBranchAddress("metNeutralEM", &metNeutralEM);
+            // calo met
+        if (t->GetBranchStatus("caloMet_Pt"))
+            t->SetBranchAddress("caloMet_Pt", &caloMet_Pt);
+        if (t->GetBranchStatus("caloMet_Phi"))
+            t->SetBranchAddress("caloMet_Phi", &caloMet_Phi);
+        if (t->GetBranchStatus("caloMet_SumEt"))
+            t->SetBranchAddress("caloMet_SumEt", &caloMet_SumEt);
     }
 }
 

--- a/Core/src/BareMonteCarlo.cpp
+++ b/Core/src/BareMonteCarlo.cpp
@@ -2,12 +2,20 @@
 #include "NeroProducer/Core/interface/BareFunctions.hpp"
 
 BareMonteCarlo::BareMonteCarlo() : BareP4(){
-    p4 = NULL;
-    pdgId = NULL;
-    jetP4 = NULL;
 }
 
 BareMonteCarlo::~BareMonteCarlo(){
+    delete jetP4;
+    delete pdgId;
+}
+
+void BareMonteCarlo::init(){
+    BareP4::init();
+
+    if (!jetP4)
+        jetP4 = new TClonesArray("TLorentzVector", 20);
+    if (!pdgId)
+        pdgId = new vector<int>;
 }
 
 void BareMonteCarlo::clear(){
@@ -31,10 +39,8 @@ void BareMonteCarlo::defineBranches(TTree *t){
     //
     BareP4::defineBranches(t, "gen" );
     //
-    jetP4 = new TClonesArray("TLorentzVector", 20);
     t->Branch("genjetP4","TClonesArray", &jetP4, 128000, 0);
     //
-    pdgId = new vector<int>;
     t->Branch("genPdgId","vector<int>", &pdgId);
     //
     t->Branch("puTrueInt",&puTrueInt,"puTrueInt/I");
@@ -52,21 +58,31 @@ void BareMonteCarlo::defineBranches(TTree *t){
 void BareMonteCarlo::setBranchAddresses(TTree *t){
     BareP4::setBranchAddresses(t,"gen");
     //
-    jetP4 = new TClonesArray("TLorentzVector", 20);
-    t->SetBranchAddress("genjetP4"	, &jetP4 );
-    pdgId = new vector<int>;
-    t->SetBranchAddress("genPdgId"	, &pdgId);
+    if (t->GetBranchStatus("genjetP4"))
+        t->SetBranchAddress("genjetP4"	, &jetP4 );
+    if (t->GetBranchStatus("genPdgId"))
+        t->SetBranchAddress("genPdgId"	, &pdgId);
     //
-    t->SetBranchAddress("puTrueInt"	,&puTrueInt	);
-    t->SetBranchAddress("mcWeight"	,&mcWeight	);
-    t->SetBranchAddress("pdfQscale"	,&qScale	);
-    t->SetBranchAddress("pdfAlphaQED"	,&alphaQED	);
-    t->SetBranchAddress("pdfAlphaQCD"	,&alphaQCD	);
-    t->SetBranchAddress("pdfX1"	,&x1		);
-    t->SetBranchAddress("pdfX2"	,&x2		);
-    t->SetBranchAddress("pdfId1"	,&pdf1Id	);
-    t->SetBranchAddress("pdfId2"	,&pdf2Id	);
-    t->SetBranchAddress("pdfScalePdf"	,&scalePdf	);
+    if (t->GetBranchStatus("puTrueInt"))
+        t->SetBranchAddress("puTrueInt"	,&puTrueInt	);
+    if (t->GetBranchStatus("mcWeight"))
+        t->SetBranchAddress("mcWeight"	,&mcWeight	);
+    if (t->GetBranchStatus("pdfQscale"))
+        t->SetBranchAddress("pdfQscale"	,&qScale	);
+    if (t->GetBranchStatus("pdfAlphaQED"))
+        t->SetBranchAddress("pdfAlphaQED"	,&alphaQED	);
+    if (t->GetBranchStatus("pdfAlphaQCD"))
+        t->SetBranchAddress("pdfAlphaQCD"	,&alphaQCD	);
+    if (t->GetBranchStatus("pdfX1"))
+        t->SetBranchAddress("pdfX1"	,&x1		);
+    if (t->GetBranchStatus("pdfX2"))
+        t->SetBranchAddress("pdfX2"	,&x2		);
+    if (t->GetBranchStatus("pdfId1"))
+        t->SetBranchAddress("pdfId1"	,&pdf1Id	);
+    if (t->GetBranchStatus("pdfId2"))
+        t->SetBranchAddress("pdfId2"	,&pdf2Id	);
+    if (t->GetBranchStatus("pdfScalePdf"))
+        t->SetBranchAddress("pdfScalePdf"	,&scalePdf	);
 }
 
 void BareMonteCarlo::compress(){

--- a/Core/src/BareP4.cpp
+++ b/Core/src/BareP4.cpp
@@ -1,6 +1,22 @@
 #include "NeroProducer/Core/interface/BareP4.hpp"
 #include "NeroProducer/Core/interface/BareFunctions.hpp"
 
+BareP4::BareP4() : BareCollection(){
+}
+
+BareP4::~BareP4(){
+    delete p4;
+    delete match;
+}
+
+void BareP4::init(){
+    if (!p4)
+        p4 = new TClonesArray("TLorentzVector", 20);
+
+    if (doMatch_ && !match)
+        match = new vector<int>;
+}
+
 void BareP4::clear(){ 
 
 	p4->Clear() ; 
@@ -10,24 +26,24 @@ void BareP4::clear(){
 
 void BareP4::defineBranches(TTree * t, string prefix)
 {
-    p4 = new TClonesArray("TLorentzVector", 20);
+    init();
+
     t->Branch( (prefix + "P4").c_str(),"TClonesArray", &p4, 128000, 0);
 
     if (doMatch_){
-    	match = new vector<int>;
     	t->Branch( (prefix+"Match").c_str(),"vector<int>",&match);
     }
 }
 
-void BareP4::setBranchAddresses(TTree*t,string prefix)
+void BareP4::setBranchAddresses(TTree* t, string prefix)
 {
-    p4 = new TClonesArray("TLorentzVector", 20);
-    t->SetBranchAddress( (prefix+"P4").c_str(), &p4	);
+    init();
 
-    if ( doMatch_){
-    	match = new vector<int>;
+    if (t->GetBranchStatus((prefix + "P4").c_str()))
+      t->SetBranchAddress( (prefix+"P4").c_str(), &p4	);
+
+    if ( doMatch_ && t->GetBranchStatus((prefix + "Match").c_str()) )
     	t->SetBranchAddress((prefix+"Match").c_str()	,&match);
-    }
 }
 
 void BareP4::compress(){

--- a/Core/src/BarePhotons.cpp
+++ b/Core/src/BarePhotons.cpp
@@ -2,24 +2,59 @@
 
 
 BarePhotons::BarePhotons():BareP4(){
-    p4 = NULL;
-    sieie = NULL;
-    iso = NULL;
-    tightid = NULL;
-    mediumid = NULL;
-    looseid = NULL;
-
-    chIso = NULL;
-    chIsoRC = NULL;
-    nhIso = NULL;
-    nhIsoRC = NULL;
-    phoIso = NULL;
-    phoIsoRC = NULL;
-    puIso = NULL;
-    puIsoRC = NULL;
 }
 
-BarePhotons::~BarePhotons(){}
+BarePhotons::~BarePhotons(){
+    delete iso;
+    delete sieie;
+    delete tightid;
+    delete mediumid;
+    delete looseid;
+    delete chIso;
+    delete chIsoRC;
+    delete nhIso;
+    delete nhIsoRC;
+    delete phoIso;
+    delete phoIsoRC;
+    delete puIso;
+    delete puIsoRC;
+}
+
+void BarePhotons::init(){
+    BareP4::init();
+
+    if (!iso)
+        iso = new vector<float>;
+    //
+    if (!sieie)
+        sieie = new vector<float>;
+    //
+    if (!tightid)
+        tightid = new vector<int>;
+    //
+    if (!mediumid)
+        mediumid = new vector<int>;
+
+    if (!looseid)
+        looseid = new vector<int>;
+
+    if (!chIso)
+        chIso = new vector<float>;
+    if (!chIsoRC)
+        chIsoRC = new vector<float>;
+    if (!nhIso)
+        nhIso = new vector<float>;
+    if (!nhIsoRC)
+        nhIsoRC = new vector<float>;
+    if (!phoIso)
+        phoIso = new vector<float>;
+    if (!phoIsoRC)
+        phoIsoRC = new vector<float>;
+    if (!puIso)
+        puIso = new vector<float>;
+    if (!puIsoRC)
+        puIsoRC = new vector<float>;
+}
 
 void BarePhotons::clear(){
     // This function clear all the internal storage and init it to an arbitrary value
@@ -44,71 +79,57 @@ void BarePhotons::defineBranches(TTree *t){
     //
     BareP4::defineBranches(t, "photon" );
     //
-    iso = new vector<float>;
     t->Branch("photonIso","vector<float>",&iso);
     //
-    sieie = new vector<float>;
     t->Branch("photonSieie","vector<float>",&sieie);
     //
-    tightid = new vector<int>;
     t->Branch("photonTightId","vector<int>",&tightid);
     //
-    mediumid = new vector<int>;
     t->Branch("photonMediumId","vector<int>",&mediumid);
 
-    looseid = new vector<int>;
     t->Branch("photonLooseId","vector<int>",&looseid);
 
-    chIso = new vector<float>;
     t->Branch("photonChIso","vector<float>",&chIso);
-    chIsoRC = new vector<float>;
     t->Branch("photonChIsoRC","vector<float>",&chIsoRC);
-    nhIso = new vector<float>;
     t->Branch("photonNhIso","vector<float>",&nhIso);
-    nhIsoRC = new vector<float>;
     t->Branch("photonNhIsoRC","vector<float>",&nhIsoRC);
-    phoIso = new vector<float>;
     t->Branch("photonPhoIso","vector<float>",&phoIso);
-    phoIsoRC = new vector<float>;
     t->Branch("photonPhoIsoRC","vector<float>",&phoIsoRC);
-    puIso = new vector<float>;
     t->Branch("photonPuIso","vector<float>",&puIso);
-    puIsoRC = new vector<float>;
     t->Branch("photonPuIsoRC","vector<float>",&puIsoRC);
-
 }
 
 void BarePhotons::setBranchAddresses(TTree *t){
 
     BareP4::setBranchAddresses(t,"photon");
 
-    iso = new vector<float>;
-    t->Branch("photonIso"	,&iso);
-    sieie = new vector<float>;
-    t->Branch("photonSieie"	,&sieie);
-    tightid = new vector<int>;
-    t->Branch("photonTightId"	,&tightid);
-    mediumid = new vector<int>;
-    t->Branch("photonMediumId"	,&mediumid);
-    looseid = new vector<int>;
-    t->Branch("photonLooseId"	,&looseid);
+    if (t->GetBranchStatus("photonIso"))
+        t->SetBranchAddress("photonIso"	,&iso);
+    if (t->GetBranchStatus("photonSieie"))
+        t->SetBranchAddress("photonSieie"	,&sieie);
+    if (t->GetBranchStatus("photonTightId"))
+        t->SetBranchAddress("photonTightId"	,&tightid);
+    if (t->GetBranchStatus("photonMediumId"))
+        t->SetBranchAddress("photonMediumId"	,&mediumid);
+    if (t->GetBranchStatus("photonLooseId"))
+        t->SetBranchAddress("photonLooseId"	,&looseid);
 
-    chIso = new vector<float>;
-    t->SetBranchAddress("photonChIso",&chIso);
-    chIsoRC = new vector<float>;
-    t->SetBranchAddress("photonChIsoRC",&chIsoRC);
-    nhIso = new vector<float>;
-    t->SetBranchAddress("photonNhIso",&nhIso);
-    nhIsoRC = new vector<float>;
-    t->SetBranchAddress("photonNhIsoRC",&nhIsoRC);
-    phoIso = new vector<float>;
-    t->SetBranchAddress("photonPhoIso",&phoIso);
-    phoIsoRC = new vector<float>;
-    t->SetBranchAddress("photonPhoIsoRC",&phoIsoRC);
-    puIso = new vector<float>;
-    t->SetBranchAddress("photonPuIso",&puIso);
-    puIsoRC = new vector<float>;
-    t->SetBranchAddress("photonPuIsoRC",&puIsoRC);
+    if (t->GetBranchStatus("photonChIso"))
+        t->SetBranchAddress("photonChIso",&chIso);
+    if (t->GetBranchStatus("photonChIsoRC"))
+        t->SetBranchAddress("photonChIsoRC",&chIsoRC);
+    if (t->GetBranchStatus("photonNhIso"))
+        t->SetBranchAddress("photonNhIso",&nhIso);
+    if (t->GetBranchStatus("photonNhIsoRC"))
+        t->SetBranchAddress("photonNhIsoRC",&nhIsoRC);
+    if (t->GetBranchStatus("photonPhoIso"))
+        t->SetBranchAddress("photonPhoIso",&phoIso);
+    if (t->GetBranchStatus("photonPhoIsoRC"))
+        t->SetBranchAddress("photonPhoIsoRC",&phoIsoRC);
+    if (t->GetBranchStatus("photonPuIso"))
+        t->SetBranchAddress("photonPuIso",&puIso);
+    if (t->GetBranchStatus("photonPuIsoRC"))
+        t->SetBranchAddress("photonPuIsoRC",&puIsoRC);
 }
 // Local Variables:
 // mode:c++

--- a/Core/src/BareTaus.cpp
+++ b/Core/src/BareTaus.cpp
@@ -1,21 +1,54 @@
 #include "NeroProducer/Core/interface/BareTaus.hpp"
 
 BareTaus::BareTaus(): BareP4() {
-    p4 = NULL;
-    id = NULL;
-    Q = NULL;
-    M = NULL;
-    iso = NULL;
-    chargedIsoPtSum = NULL;
-    neutralIsoPtSum = NULL;
-    isoDeltaBetaCorr = NULL;
-    againstEleLoose = NULL;
-    againstEleMedium = NULL;
-    againstMuLoose = NULL;
-    againstMuTight = NULL;
 }
 
 BareTaus::~BareTaus(){
+    delete id;
+    delete Q;
+    delete M;
+    delete iso;
+    delete chargedIsoPtSum;
+    delete neutralIsoPtSum;
+    delete isoDeltaBetaCorr;
+    delete againstEleLoose;
+    delete againstEleMedium;
+    delete againstMuLoose;
+    delete againstMuTight;
+}
+
+void BareTaus::init(){
+    BareP4::init();
+
+    if (!id)
+        id = new vector<float>;
+    //
+    if (!Q)
+        Q = new vector<int>;
+    //
+    if (!M)
+        M = new vector<float>;
+    //
+    if (!iso)
+        iso = new vector<float>;
+
+    if ( IsExtend() )
+        {
+            if (!chargedIsoPtSum)
+                chargedIsoPtSum = new vector<float>;
+            if (!neutralIsoPtSum)
+                neutralIsoPtSum = new vector<float> ;
+            if (!isoDeltaBetaCorr)
+                isoDeltaBetaCorr = new vector<float>;
+            if (!againstEleLoose)
+                againstEleLoose = new vector<int>;
+            if (!againstEleMedium)
+                againstEleMedium = new vector<int>;
+            if (!againstMuLoose)
+                againstMuLoose = new vector<int>;
+            if (!againstMuTight)
+                againstMuTight = new vector<int>;
+        }
 }
 
 void BareTaus::clear(){
@@ -39,33 +72,22 @@ void BareTaus::clear(){
 void BareTaus::defineBranches(TTree *t){
     BareP4::defineBranches(t, "tau" );
     //
-    id = new vector<float>;
     t->Branch("tauId","vector<float>",&id);
     //
-    Q = new vector<int>;
     t->Branch("tauQ","vector<int>",&Q);
     //
-    M = new vector<float>;
     t->Branch("tauM","vector<float>",&M);
     //
-    iso = new vector<float>;
     t->Branch("tauIso","vector<float>",&iso);
 
     if ( IsExtend() )
         {
-        chargedIsoPtSum = new vector<float>;
         t->Branch("tauChargedIsoPtSum","vector<float>",&chargedIsoPtSum);
-        neutralIsoPtSum = new vector<float> ;
         t->Branch("tauNeutralIsoPtSum","vector<float>",&neutralIsoPtSum);
-        isoDeltaBetaCorr = new vector<float>;
         t->Branch("tauIsoDeltaBetaCorr","vector<float>",&isoDeltaBetaCorr);
-        againstEleLoose = new vector<int>;
         t->Branch("tauAgainstEleLoose","vector<int>",&againstEleLoose);
-        againstEleMedium = new vector<int>;
         t->Branch("tauAgainstEleMedium","vector<int>",&againstEleMedium);
-        againstMuLoose = new vector<int>;
         t->Branch("tauAgainstMuLoose","vector<int>",&againstMuLoose);
-        againstMuTight = new vector<int>  ;
         t->Branch("tauAgainstMuTight","vector<int>",&againstMuTight);
         }
 
@@ -74,41 +96,35 @@ void BareTaus::defineBranches(TTree *t){
 void BareTaus::setBranchAddresses(TTree *t){
     BareP4::setBranchAddresses(t,"tau");
 
-    id = new vector<float>;
-    t->SetBranchAddress("tauId"	,&id);
+    if (t->GetBranchStatus("tauId"))
+        t->SetBranchAddress("tauId"	,&id);
     //
-    Q = new vector<int>;
-    t->SetBranchAddress("tauQ"	,&Q);
+    if (t->GetBranchStatus("tauQ"))
+        t->SetBranchAddress("tauQ"	,&Q);
     //
-    M = new vector<float>;
-    t->SetBranchAddress("tauM"	,&M);
+    if (t->GetBranchStatus("tauM"))
+        t->SetBranchAddress("tauM"	,&M);
     //
-    iso = new vector<float>;
-    t->SetBranchAddress("tauIso"	,&iso);
+    if (t->GetBranchStatus("tauIso"))
+        t->SetBranchAddress("tauIso"	,&iso);
 
     // EXTENDED VARIBALES
     if ( IsExtend() )
         {
-        chargedIsoPtSum = new vector<float>;
-        t->SetBranchAddress("tauChargedIsoPtSum",&chargedIsoPtSum);
-
-        neutralIsoPtSum = new vector<float> ;
-        t->SetBranchAddress("tauNeutralIsoPtSum",&neutralIsoPtSum);
-
-        isoDeltaBetaCorr = new vector<float>;
-        t->SetBranchAddress("tauIsoDeltaBetaCorr",&isoDeltaBetaCorr);
-
-        againstEleLoose = new vector<int>;
-        t->SetBranchAddress("tauAgainstEleLoose",&againstEleLoose);
-
-        againstEleMedium = new vector<int>;
-        t->SetBranchAddress("tauAgainstEleMedium",&againstEleMedium);
-
-        againstMuLoose = new vector<int>;
-        t->SetBranchAddress("tauAgainstMuLoose",&againstMuLoose);
-
-        againstMuTight = new vector<int>  ;
-        t->SetBranchAddress("tauAgainstMuTight",&againstMuTight);
+            if (t->GetBranchStatus("tauChargedIsoPtSum"))
+                  t->SetBranchAddress("tauChargedIsoPtSum",&chargedIsoPtSum);
+            if (t->GetBranchStatus("tauNeutralIsoPtSum"))
+                t->SetBranchAddress("tauNeutralIsoPtSum",&neutralIsoPtSum);
+            if (t->GetBranchStatus("tauIsoDeltaBetaCorr"))
+                t->SetBranchAddress("tauIsoDeltaBetaCorr",&isoDeltaBetaCorr);
+            if (t->GetBranchStatus("tauAgainstEleLoose"))
+                t->SetBranchAddress("tauAgainstEleLoose",&againstEleLoose);
+            if (t->GetBranchStatus("tauAgainstEleMedium"))
+                t->SetBranchAddress("tauAgainstEleMedium",&againstEleMedium);
+            if (t->GetBranchStatus("tauAgainstMuLoose"))
+                t->SetBranchAddress("tauAgainstMuLoose",&againstMuLoose);
+            if (t->GetBranchStatus("tauAgainstMuTight"))
+                t->SetBranchAddress("tauAgainstMuTight",&againstMuTight);
         }
 }
 // Local Variables:

--- a/Core/src/BareTrigger.cpp
+++ b/Core/src/BareTrigger.cpp
@@ -1,11 +1,37 @@
 #include "NeroProducer/Core/interface/BareTrigger.hpp"
 
-BareTrigger::BareTrigger():BareCollection(){
-    triggerFired=NULL;
-    triggerNames = new vector<string>;
+BareTrigger::BareTrigger():
+    BareCollection(),
+    triggerNames(new vector<string>)
+{
 }
-BareTrigger::~BareTrigger(){}
 
+BareTrigger::~BareTrigger(){
+    delete triggerNames;
+
+    delete triggerFired;
+    delete triggerPrescale;
+    delete triggerLeps;
+    delete triggerJets;
+    delete triggerTaus;
+    delete triggerPhotons;
+}
+
+void BareTrigger::init(){
+    if (!triggerFired)
+        triggerFired =new vector<int>;
+    if (!triggerPrescale)
+        triggerPrescale =new vector<float>;
+    // ---
+    if (!triggerLeps)
+        triggerLeps =new vector<int>;
+    if (!triggerJets)
+        triggerJets =new vector<int>;
+    if (!triggerTaus)
+        triggerTaus =new vector<int>;
+    if (!triggerPhotons)
+        triggerPhotons =new vector<int>;
+}
 
 void BareTrigger::clear(){
 
@@ -19,37 +45,34 @@ void BareTrigger::clear(){
 }
 
 void BareTrigger::defineBranches(TTree *t){
-    triggerFired =new vector<int>;
+    init();
+
     t->Branch("triggerFired","vector<int>",&triggerFired);
-    triggerPrescale =new vector<float>;
     t->Branch("triggerPrescale","vector<float>",&triggerPrescale);
     // ---
-    triggerLeps =new vector<int>;
     t->Branch("triggerLeps","vector<int>",&triggerLeps);
-    triggerJets =new vector<int>;
     t->Branch("triggerJets","vector<int>",&triggerLeps);
-    triggerTaus =new vector<int>;
     t->Branch("triggerTaus","vector<int>",&triggerTaus);
-    triggerPhotons =new vector<int>;
     t->Branch("triggerPhotons","vector<int>",&triggerPhotons);
 }
 
 void BareTrigger::setBranchAddresses(TTree*t)
 {
-    triggerFired =new vector<int>;
-    triggerPrescale =new vector<float>;
+    init();
+
+    if (t->GetBranchStatus("triggerFired"))
+        t -> SetBranchAddress("triggerFired", &triggerFired);
+    if (t->GetBranchStatus("triggerPrescale"))
+        t -> SetBranchAddress("triggerPrescale", &triggerPrescale);
     // ---
-    triggerLeps =new vector<int>;
-    triggerJets =new vector<int>;
-    triggerTaus =new vector<int>;
-    triggerPhotons =new vector<int>;
-    t -> SetBranchAddress("triggerFired", &triggerFired);
-    t -> SetBranchAddress("triggerPrescale", &triggerPrescale);
-    // ---
-    t -> SetBranchAddress("triggerLeps", &triggerLeps);
-    t -> SetBranchAddress("triggerJets", &triggerJets);
-    t -> SetBranchAddress("triggerTaus", &triggerTaus);
-    t -> SetBranchAddress("triggerPhotons", &triggerPhotons);
+    if (t->GetBranchStatus("triggerLeps"))
+        t -> SetBranchAddress("triggerLeps", &triggerLeps);
+    if (t->GetBranchStatus("triggerJets"))
+        t -> SetBranchAddress("triggerJets", &triggerJets);
+    if (t->GetBranchStatus("triggerTaus"))
+        t -> SetBranchAddress("triggerTaus", &triggerTaus);
+    if (t->GetBranchStatus("triggerPhotons"))
+        t -> SetBranchAddress("triggerPhotons", &triggerPhotons);
 }
 
 // Local Variables:

--- a/Core/src/BareVertex.cpp
+++ b/Core/src/BareVertex.cpp
@@ -17,7 +17,8 @@ void BareVertex::defineBranches(TTree *t){
 }
 void BareVertex::setBranchAddresses(TTree *t){
     // nothing to be done
-    t->SetBranchAddress("npv"     ,&npv );
+    if (t->GetBranchStatus("npv"))
+        t->SetBranchAddress("npv"     ,&npv );
 }
 
 // Local Variables:


### PR DESCRIPTION
Adding functions to BareCollection, BareP4 and derived classes for ease of use when running analysis on Nero files using these classes.
 - virtual unsigned size()
 - virtual void init() to new pointer members
 - setBranchAddresses() only picks branches with nonzero status
 - Proposing convention to zero out pointer members in the class definition (allowed since C++11) to avoid the common error of uninitialized pointers.