### PR TITLE
GetByToken

### DIFF
--- a/Nero/interface/NeroAll.hpp
+++ b/Nero/interface/NeroAll.hpp
@@ -29,12 +29,19 @@ class NeroAll : virtual public NeroCollection,
         edm::Handle<std::vector<long> > events_handle;
         edm::Handle<std::vector<float> > weights_handle;
         edm::Handle<std::vector<int> > putrue_handle;
+
+        edm::EDGetTokenT<std::vector<long> > events_token;
+        edm::EDGetTokenT<std::vector<float> > weights_token;
+        edm::EDGetTokenT<std::vector<int> > putrue_token;
+
         // from PAT-MINIAOD
+        // needs to be checked. Not using it at the moment
         edm::EDGetTokenT<GenEventInfoProduct> info_token;
         edm::Handle<GenEventInfoProduct> info_handle;
 
         edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pu_token;
         edm::Handle< std::vector<PileupSummaryInfo> > pu_handle;
+
 
         // --- Token
         // this are constructed by tFileservice at beginJob

--- a/Nero/plugins/Nero.cc
+++ b/Nero/plugins/Nero.cc
@@ -183,7 +183,7 @@ Nero::Nero(const edm::ParameterSet& iConfig)
     mc -> info_token   = consumes<GenEventInfoProduct>(iConfig.getParameter<edm::InputTag>("generator"));
     mc -> pu_token     = consumes<std::vector<PileupSummaryInfo> >(iConfig.getParameter<edm::InputTag>("pileup"));
     mc -> jet_token    = consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("genjets"));
-    mc -> runinfo_token = consumes<GenRunInfoProduct>(iConfig.getParameter<edm::InputTag>("genruninfo") );
+    mc -> runinfo_token = consumes<GenRunInfoProduct,edm::InRun>(iConfig.getParameter<edm::InputTag>("genruninfo") );
     mc -> mMinGenParticlePt = iConfig.getParameter<double>("minGenParticlePt");
     mc -> mMinGenJetPt = iConfig.getParameter<double>("minGenJetPt");
     mc -> mParticleGun = iConfig.getUntrackedParameter<bool>("particleGun",false);
@@ -221,6 +221,11 @@ Nero::Nero(const edm::ParameterSet& iConfig)
     NeroAll *info = new NeroAll();
     info -> mOnlyMc = onlyMc;
     info -> isSkim_ = 1;
+    //info -> pu_token = consumes<std::vector<PileupSummaryInfo> >(edm::InputTag("addPileupInfo"));
+    //info -> info_token = consumes<GenEventInfoProduct>(edm::InputTag("generator"));
+    info -> events_token = consumes<std::vector<long>,edm::InLumi>( edm::InputTag("InfoProducer","vecEvents") ) ;
+    info -> weights_token = consumes<std::vector<float>,edm::InLumi>( edm::InputTag("InfoProducer","vecMcWeights") ) ;
+    info -> putrue_token = consumes<std::vector<int>,edm::InLumi>( edm::InputTag("InfoProducer","vecPuTrueInt") ) ;
     lumiObj.push_back(info);
 
 

--- a/Nero/src/NeroAll.cpp
+++ b/Nero/src/NeroAll.cpp
@@ -35,8 +35,12 @@ int NeroAll::analyze(const edm::Event&iEvent)
         eventNum = iEvent.id().event();  
 
         if( not isRealData ) {
-            iEvent.getByLabel(edm::InputTag("generator"), info_handle); // USE TOKEN AND INPUT TAG ?
-            iEvent.getByLabel(edm::InputTag("addPileupInfo"), pu_handle);
+            //iEvent.getByLabel(edm::InputTag("generator"), info_handle); // USE TOKEN AND INPUT TAG ?
+            //iEvent.getByLabel(edm::InputTag("addPileupInfo"), pu_handle);
+            //TODO! don't use this path for the moment. Check that double fetching the token still work
+            iEvent.getByToken(info_token,info_handle);
+            iEvent.getByToken(pu_token,pu_handle );
+
             if (not info_handle.isValid() ) cout<<"[NeroAll]::[analyze]::[ERROR] Info handle is not valid"<<endl;
             if (not pu_handle.isValid() ) cout <<"[NeroAll]::[analyze]::[ERROR] PU handle is not valide"<<endl;
             mcWeight = info_handle->weight();
@@ -60,10 +64,14 @@ int NeroAll::analyzeLumi(const edm::LuminosityBlock &iLumi, TTree *t)
 
     if(VERBOSE>1) cout<<"[NeroAll]::[analyzeLumi]::[DEBUG] isMc_"<<isMc_<<endl;
 
-    iLumi.getByLabel(edm::InputTag("InfoProducer","vecEvents"), events_handle);
+    //iLumi.getByLabel(edm::InputTag("InfoProducer","vecEvents"), events_handle);
 
-    iLumi.getByLabel(edm::InputTag("InfoProducer","vecMcWeights"), weights_handle);
-    iLumi.getByLabel(edm::InputTag("InfoProducer","vecPuTrueInt"), putrue_handle);
+    //iLumi.getByLabel(edm::InputTag("InfoProducer","vecMcWeights"), weights_handle);
+    //iLumi.getByLabel(edm::InputTag("InfoProducer","vecPuTrueInt"), putrue_handle);
+
+    iLumi.getByToken( events_token, events_handle);
+    iLumi.getByToken( weights_token, weights_handle);
+    iLumi.getByToken( putrue_token, putrue_handle);
 
     if ( not events_handle.isValid() ) cout<<"[NeroAll]::[analyzeLumi]::[ERROR] events_handle is not valid"<<endl;
     if ( not weights_handle.isValid() ) cout<<"[NeroAll]::[analyzeLumi]::[ERROR] weights_handle is not valid"<<endl;

--- a/Nero/src/NeroMonteCarlo.cpp
+++ b/Nero/src/NeroMonteCarlo.cpp
@@ -162,8 +162,8 @@ int NeroMonteCarlo::crossSection(edm::Run const & iRun, TH1F* h)
     // will be run at the end of run
     if ( isRealData ) return 0; // if the first run has no events ?  TODO
 
-    //iRun.getByToken( runinfo_token, runinfo_handle);
-    iRun.getByLabel( "generator", runinfo_handle);
+    iRun.getByToken( runinfo_token, runinfo_handle);
+    //iRun.getByLabel( "generator", runinfo_handle);
 
     if ( not runinfo_handle.isValid() ) cout<<"[NeroMonteCarlo]::[crossSection]::[ERROR] runinfo_handle is not valid"<<endl;
     if (not runinfo_handle . isValid() ) return 0;


### PR DESCRIPTION
* moving the getByLabel to getByToken (also for the InRun and InLumi products) 
* still missing the Hbb tagger, that will in anycase not be recomputed in the next releases but taken from the miniAOD directly.
* it is done for the compatibility with future versions that will enforce this way.