### PR TITLE
forgot electron veto on photons

### DIFF
--- a/Bambu/macros/bambuToNero.py
+++ b/Bambu/macros/bambuToNero.py
@@ -268,6 +268,7 @@ loosePhotons = mithep.PhotonIdMod('LoosePhotons',
     OutputName = 'LoosePhotons',
     IdType = mithep.PhotonTools.kSummer15Loose,
     IsoType = mithep.PhotonTools.kSummer15LooseIso,
+    ApplyCSafeElectronVeto = True,
     PtMin = 15.,
     EtaMax = 2.5
 )


### PR DESCRIPTION
We found a bug in the PhotonIdMod last time because setting the ApplyVeto to true did not change anything, but then forgot to keep it on.