### PR TITLE
bug fix nvtx

### DIFF
--- a/Nero/src/NeroVertex.cpp
+++ b/Nero/src/NeroVertex.cpp
@@ -29,6 +29,7 @@ int NeroVertex::analyze(const edm::Event& iEvent){
     // good quality criteria
     VertexCollection::const_iterator firstGoodVertex = handle->end();
     firstGoodVertexIdx = -1;
+    npv=0;
     for (VertexCollection::const_iterator vtx = handle->begin(); 
             vtx != handle->end(); ++vtx) {
         bool isFake = (vtx->chi2()==0 && vtx->ndof()==0);


### PR DESCRIPTION
Miniaod has a consistent shift of 1 in npv.
In anycase 1 (correctly count) good npv is still be asked in the ntuple making. 