### PR TITLE
removing transfer_output_files for default

### DIFF
--- a/Bambu/config/condor_template.jdl
+++ b/Bambu/config/condor_template.jdl
@@ -1,6 +1,8 @@
 Requirements            = Arch == "X86_64" && OpSysAndVer == "SL6" && HasFileTransfer
 Notification            = Error
 Rank                    = Mips
-transfer_output_files = {fileset}.root,nero.root
-transfer_output_remaps = "nero.root = nero_{fileset}.root"
+# Uncomment below if a local copy of ntuples are needed
+#transfer_output_files = {fileset}.root,nero.root
+#transfer_output_remaps = "nero.root = nero_{fileset}.root"
+transfer_output_files = {fileset}.root
 accounting_group = group_cmsuser


### PR DESCRIPTION
Updating the condor configuration so that no local copy of the ntuples are produced in T3 by default.