### PR TITLE
shuffling the photon id enum around

### DIFF
--- a/Core/interface/BarePhotons.hpp
+++ b/Core/interface/BarePhotons.hpp
@@ -14,14 +14,14 @@ class BarePhotons : virtual public BareP4
             PhoMedium = 1UL << 4,
             PhoTight  = 1UL << 5,
             PhoElectronVeto = 1UL << 7,
+            PhoPixelSeedVeto = 1UL << 8,
             // NONPOG
-            PhoVLoose50 = 1UL << 8, // loose, no-sieie, looser ph-iso
-            PhoVLoose25 = 1UL << 9, // loose + no-sieie, looser ph-iso
-            PhoHighPt = 1UL << 10,
-            PhoLooseNoEVeto = 1UL << 11,
-            PhoMediumNoEVeto = 1UL << 12,
-            PhoTightNoEVeto = 1UL << 13,
-            PhoPixelSeedVeto = 1UL << 14
+            PhoVLoose50 = 1UL << 16, // loose, no-sieie, looser ph-iso
+            PhoVLoose25 = 1UL << (PhoVLoose50 + 1), // loose + no-sieie, looser ph-iso
+            PhoHighPt = 1UL << (PhoVLoose50 + 2),
+            PhoLooseNoEVeto = 1UL << (PhoVLoose50 + 3),
+            PhoMediumNoEVeto = 1UL << (PhoVLoose50 + 4),
+            PhoTightNoEVeto = 1UL << (PhoVLoose50 + 5)
         };
 
         BarePhotons();


### PR DESCRIPTION
Following Brandon's suggestion to "break the backward compatibility now than later".
In any case, source code should be backward compatible as long as it was using enums to access the corresponding ID bits.