### PR TITLE
Updating to actually allow monophoton analysis to use Nero input

### DIFF
--- a/Core/interface/BarePhotons.hpp
+++ b/Core/interface/BarePhotons.hpp
@@ -21,7 +21,8 @@ class BarePhotons : virtual public BareP4
             PhoHighPt = 1UL << 18,
             PhoLooseNoEVeto = 1UL << 19,
             PhoMediumNoEVeto = 1UL << 20,
-            PhoTightNoEVeto = 1UL << 21
+            PhoTightNoEVeto = 1UL << 21,
+            PhoMonophBaseline = 1UL << 22
         };
 
         BarePhotons();
@@ -54,12 +55,17 @@ class BarePhotons : virtual public BareP4
 
         // EXTENDED VARIABLES
         vector<float> *rawpt{0};
-        vector<float> *e55{0};
+        vector<float> *rawScEnergy{0};
 
         vector<float> *hOverE{0};
         vector<float> *chWorstIso{0};
         vector<float> *chIsoMax{0};
     
+        vector<float> *emax{0};
+        vector<float> *e2nd{0};
+        vector<float> *e33{0};
+        vector<float> *e55{0};
+
         vector<float> *sipip{0};
         vector<float> *sieip{0};
         vector<float> *r9{0};

--- a/Core/src/BarePhotons.cpp
+++ b/Core/src/BarePhotons.cpp
@@ -14,10 +14,14 @@ BarePhotons::~BarePhotons(){
     BareFunctions::Delete(phoIso);
     BareFunctions::Delete(puIso);
     BareFunctions::Delete(rawpt);
-    BareFunctions::Delete(e55);
+    BareFunctions::Delete(rawScEnergy);
     BareFunctions::Delete(hOverE);
     BareFunctions::Delete(chWorstIso);
     BareFunctions::Delete(chIsoMax);
+    BareFunctions::Delete(emax);
+    BareFunctions::Delete(e2nd);
+    BareFunctions::Delete(e33);
+    BareFunctions::Delete(e55);
     BareFunctions::Delete(sipip);
     BareFunctions::Delete(sieip);
     BareFunctions::Delete(r9);
@@ -42,10 +46,14 @@ void BarePhotons::init(){
 
     if (IsExtend()) {
         BareFunctions::New(rawpt);
-        BareFunctions::New(e55);
+        BareFunctions::New(rawScEnergy);
         BareFunctions::New(hOverE);
         BareFunctions::New(chWorstIso);
         BareFunctions::New(chIsoMax);
+        BareFunctions::New(emax);
+        BareFunctions::New(e2nd);
+        BareFunctions::New(e33);
+        BareFunctions::New(e55);
         BareFunctions::New(sipip);
         BareFunctions::New(sieip);
         BareFunctions::New(r9);
@@ -72,10 +80,14 @@ void BarePhotons::clear(){
 
     if (extend_) {
         rawpt->clear();
-        e55->clear();
+        rawScEnergy->clear();
         hOverE->clear();
         chWorstIso->clear();
         chIsoMax->clear();
+        emax->clear();
+        e2nd->clear();
+        e33->clear();
+        e55->clear();
         sipip->clear();
         sieip->clear();
         r9->clear();
@@ -106,10 +118,14 @@ void BarePhotons::defineBranches(TTree *t){
 
     if (IsExtend()) {
         t->Branch("photonRawPt", "vector<float>", &rawpt);
-        t->Branch("photonE55", "vector<float>", &e55);
+        t->Branch("photonRawScEnergy", "vector<float>", &rawScEnergy);
         t->Branch("photonHOverE", "vector<float>", &hOverE);
         t->Branch("photonChWorstIso", "vector<float>", &chWorstIso);
         t->Branch("photonChIsoMax", "vector<float>", &chIsoMax);
+        t->Branch("photonEmax", "vector<float>", &emax);
+        t->Branch("photonE2nd", "vector<float>", &e2nd);
+        t->Branch("photonE33", "vector<float>", &e33);
+        t->Branch("photonE55", "vector<float>", &e55);
         t->Branch("photonSipip", "vector<float>", &sipip);
         t->Branch("photonSieip", "vector<float>", &sieip);
         t->Branch("photonR9", "vector<float>", &r9);
@@ -137,10 +153,14 @@ void BarePhotons::setBranchAddresses(TTree *t){
 
     if (IsExtend()) {
         BareFunctions::SetBranchAddress(t, "photonRawPt", &rawpt);
-        BareFunctions::SetBranchAddress(t, "photonE55", &e55);
+        BareFunctions::SetBranchAddress(t, "photonRawScEnergy", &rawScEnergy);
         BareFunctions::SetBranchAddress(t, "photonHOverE", &hOverE);
         BareFunctions::SetBranchAddress(t, "photonChWorstIso", &chWorstIso);
         BareFunctions::SetBranchAddress(t, "photonChIsoMax", &chIsoMax);
+        BareFunctions::SetBranchAddress(t, "photonEmax", &emax);
+        BareFunctions::SetBranchAddress(t, "photonE2nd", &e2nd);
+        BareFunctions::SetBranchAddress(t, "photonE33", &e33);
+        BareFunctions::SetBranchAddress(t, "photonE55", &e55);
         BareFunctions::SetBranchAddress(t, "photonSipip", &sipip);
         BareFunctions::SetBranchAddress(t, "photonSieip", &sieip);
         BareFunctions::SetBranchAddress(t, "photonR9", &r9);

--- a/Nero/interface/NeroPhotons.hpp
+++ b/Nero/interface/NeroPhotons.hpp
@@ -62,6 +62,8 @@ class NeroPhotons : virtual public NeroCollection,
         int   mMinNpho;
         float mMaxEta;
         float mMaxIso;
+        string mMinId;
+        unsigned kMinId;
 
         // -- PF
         NeroPF *pf;
@@ -74,6 +76,8 @@ class NeroPhotons : virtual public NeroCollection,
 
         // needed to be constructed during the plugin construction
         //SuperClusterFootprintRemovalMiniAOD  *fpr;
+
+        unsigned idStringToEnum(std::string idString);
 
         bool cutBasedPhotonId( const pat::Photon& pho, string type="loose_50ns", bool withIso = true , bool withSieie=true);
 

--- a/Nero/plugins/Nero.cc
+++ b/Nero/plugins/Nero.cc
@@ -273,6 +273,7 @@ Nero::Nero(const edm::ParameterSet& iConfig)
     phos -> mMinPt = iConfig.getParameter<double>("minPhoPt");
     phos -> mMaxIso = iConfig.getParameter<double>("maxPhoIso");
     phos -> mMinNpho = iConfig.getParameter<int>("minPhoN");
+    phos -> mMinId = iConfig.getParameter<string>("minPhoId");
     phos -> mMaxEta = iConfig.getParameter<double>("minPhoEta");
     phos -> SetMatch( iConfig.getParameter<bool>("matchPho") );
     phos -> pf = pf;

--- a/Nero/python/NeroMonojet_cfi.py
+++ b/Nero/python/NeroMonojet_cfi.py
@@ -53,4 +53,4 @@ nero.minTauId  = cms.string ('decayModeFinding')
 nero.maxTauIso = cms.double (5)
 nero.extendTau = cms.bool(False)
 nero.extendMet = cms.bool(True)
-
+nero.minPhoId = cms.string ('monoph')

--- a/Nero/python/Nero_cfi.py
+++ b/Nero/python/Nero_cfi.py
@@ -210,11 +210,13 @@ nero = cms.EDAnalyzer("Nero",
     minGenParticlePt = cms.double(5.),
     minGenJetPt = cms.double(20.),
     particleGun = cms.untracked.bool(False),
-                      
+
+    # PHOTONS
     extendPhotons = cms.bool(True),
     minPhoPt  = cms.double (15.),
     minPhoEta = cms.double (2.5),
     minPhoN   = cms.int32  (0),
+    minPhoId = cms.string ('loose'),
     maxPhoIso = cms.double (-1.),
     matchPho  = cms.bool (True),
     matchPhoDr = cms.double (0.3),


### PR DESCRIPTION
Added rawScEnergy, various shower shape energies, changed sieip and sipip to use full 5x5, added new id bit that contains all photons needed for monophoton analysis, added a way to change the minimum photon selection at config file level.