### PR TITLE
Changes for lepton reco measurements

### DIFF
--- a/Core/interface/BareLeptons.hpp
+++ b/Core/interface/BareLeptons.hpp
@@ -16,10 +16,13 @@ class BareLeptons : virtual public BareP4
           LepMedium   = 1UL<<5,
           LepTight    = 1UL<<6,
           // 1 -- 6 POG
-          LepEBEE = 1UL <<7, // lepton (electron) is not in the EB-EE crack
+          LepEBEE     = 1UL<<7, // lepton (electron) is not in the EB-EE crack
           LepMediumIP = 1UL<<8,
           LepTightIP  = 1UL<<9,
           LepSoftIP   = 1UL<<10,
+          MuStandalone = 1UL<<11,
+          MuGlobal     = 1UL<<12,
+          MuTracker    = 1UL<<13,
           EleTripleCharge = 1UL<<15, // charge is in agreement between different measurements
           EleNoMissingHits = 1UL<<16
         };

--- a/Nero/interface/NeroLeptons.hpp
+++ b/Nero/interface/NeroLeptons.hpp
@@ -103,6 +103,10 @@ class NeroLeptons : virtual public NeroCollection,
         float mMaxIso_mu;
 
         int mMinNleptons;
+        string mMinId;
+        unsigned kMinId;
+
+        unsigned idStringToEnum(std::string idString);
 
         // --- EGTools
         //EnergyScaleCorrection_class *EleCorr{0};

--- a/Nero/plugins/Nero.cc
+++ b/Nero/plugins/Nero.cc
@@ -240,6 +240,8 @@ Nero::Nero(const edm::ParameterSet& iConfig)
     leps -> mMinEta_el = iConfig.getParameter<double>("minEleEta");
     leps -> mMaxIso_el = iConfig.getParameter<double>("maxEleIso");
 
+    leps -> mMinId = iConfig.getParameter<int>("minLepId");
+
     leps -> mMinNleptons = iConfig.getParameter<int>("minLepN");
     leps -> SetMatch( iConfig.getParameter<bool>("matchLep") );
 

--- a/Nero/plugins/Nero.cc
+++ b/Nero/plugins/Nero.cc
@@ -240,7 +240,7 @@ Nero::Nero(const edm::ParameterSet& iConfig)
     leps -> mMinEta_el = iConfig.getParameter<double>("minEleEta");
     leps -> mMaxIso_el = iConfig.getParameter<double>("maxEleIso");
 
-    leps -> mMinId = iConfig.getParameter<int>("minLepId");
+    leps -> mMinId = iConfig.getParameter<string>("minLepId");
 
     leps -> mMinNleptons = iConfig.getParameter<int>("minLepN");
     leps -> SetMatch( iConfig.getParameter<bool>("matchLep") );

--- a/Nero/python/NeroLeptonReco_cfi.py
+++ b/Nero/python/NeroLeptonReco_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+from NeroProducer.Nero.Nero_cfi import nero
+
+print " ------- LOADING LEPTON RECO CONFIGURATION -------- "
+
+nero.info = cms.string("NeroLeptonReco")
+nero.minPhoPt  = cms.double (10.),
+nero.minPhoId  = cms.string ('none'),
+
+# right now these are the defaults, but enforce the values
+nero.minPhoEta = cms.double (2.5),
+nero.minMuPt   = cms.double (10.),
+nero.minMuEta  = cms.double (2.4),
+nero.maxMuIso  = cms.double (-1),
+nero.minElePt  = cms.double (10.),
+nero.minEleEta = cms.double (2.5),
+nero.maxEleIso = cms.double (-1.),

--- a/Nero/python/NeroLeptonReco_cfi.py
+++ b/Nero/python/NeroLeptonReco_cfi.py
@@ -6,6 +6,7 @@ print " ------- LOADING LEPTON RECO CONFIGURATION -------- "
 nero.info = cms.string("NeroLeptonReco")
 nero.minPhoPt  = cms.double (10.),
 nero.minPhoId  = cms.string ('none'),
+nero.minLepId  = cms.string ('none'),
 
 # right now these are the defaults, but enforce the values
 nero.minPhoEta = cms.double (2.5),

--- a/Nero/python/Nero_cfi.py
+++ b/Nero/python/Nero_cfi.py
@@ -232,7 +232,8 @@ nero = cms.EDAnalyzer("Nero",
     minCA15PuppiN   = cms.int32  (0),
     minCA15PuppiId  = cms.string ('loose'),
     CA15PuppiName   = cms.string ('CA15Puppi'),
-
+    
+    ## LEPTONS
     minElePt  = cms.double (10.),
     minEleEta = cms.double (2.5),
     maxEleIso = cms.double (-1.),
@@ -240,6 +241,7 @@ nero = cms.EDAnalyzer("Nero",
     minMuPt   = cms.double (10.),
     minMuEta  = cms.double (2.4),
     maxMuIso  = cms.double (-1),
+    minLepId  = cms.string ('veto'),
    
     minLepN   = cms.int32 (0),
     matchLep  = cms.bool (True),

--- a/Nero/src/NeroLeptons.cpp
+++ b/Nero/src/NeroLeptons.cpp
@@ -30,11 +30,22 @@ NeroLeptons::~NeroLeptons(){
     //delete rnd_; 
 }
 
-
+unsigned NeroLeptons::idStringToEnum(std::string idString)
+{
+    unsigned idEnum = 0;
+    if (idString == "veto")          { idEnum = LepVeto;     }
+    else if (idString == "loose")    { idEnum = LepLoose;    }
+    else if (idString == "medium")   { idEnum = LepMedium;   }
+    else if (idString == "tight")    { idEnum = LepTight;    }
+    else if (idString == "none")     { idEnum = LepBaseline; }
+    return idEnum;
+}
 int NeroLeptons::analyze(const edm::Event & iEvent)
 {
     if ( mOnlyMc  ) return 0;
 
+    kMinId = idStringToEnum(mMinId);
+    
     if ( vtx_ == NULL) cout<<"[NeroLeptons]::[analyze]::[WARNING] Vertex Class not set."<<endl;
     if ( vtx_ -> GetPV() == NULL) cout<<"[NeroLeptons]::[analyze]::[WARNING] Primary Vertex not set."<<endl;
     if ( evt_ == NULL) cout<<"[NeroLeptons]::[analyze]::[WARNING] Event Class not set."<<endl;
@@ -63,7 +74,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
     for (const pat::Muon &mu : *mu_handle) {
         // selection
         if (mu.pt() < 5. ) continue;
-        if (mu.pt() < mMinPt_mu || fabs(mu.eta()) > mMinEta_mu || !mu.isLooseMuon()) continue; 
+        if (mu.pt() < mMinPt_mu || fabs(mu.eta()) > mMinEta_mu ) continue; 
         float chiso  = mu.pfIsolationR04().sumChargedHadronPt;
         float niso   = mu.pfIsolationR04().sumNeutralHadronEt;
         float phoiso = mu.pfIsolationR04().sumPhotonEt;
@@ -79,6 +90,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
         l.iso = totiso;
         l.p4.SetPxPyPzE( mu.px(),mu.py(),mu.pz(),mu.energy());
         l.selBits =  0 ;
+            l.selBits |= unsigned(mu.isLooseMuon()) * LepVeto;  // fill veto bit with loose info
             l.selBits |= unsigned(mu.isLooseMuon()) * LepLoose;
             l.selBits |= unsigned(mu.isTightMuon( * vtx_->GetPV() ))*LepTight ;
             l.selBits |= unsigned(mu.isMediumMuon() * LepMedium);
@@ -100,7 +112,8 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
         l.phoiso = phoiso;
         l.puiso  = puiso;
         l.miniiso = getPFMiniIsolation_DeltaBeta(pf_->handle, dynamic_cast<const reco::Candidate *>(&mu), 0.05, 0.2, 10., false);
-
+        
+        if ( not (l.selBits & kMinId) ) continue;
         leptons.push_back(l);
     }
 
@@ -112,17 +125,14 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
 
         if ( el.pt() < 10 ) continue;
         if ( el.pt() < mMinPt_el || fabs(el.eta()) > mMinEta_el ) continue;
-        if ( not el.passConversionVeto() ) continue;  // ve
 
         edm::RefToBase<pat::Electron> ref ( edm::Ref< pat::ElectronCollection >(el_handle, iEle) ) ;
 
-        bool isPassVeto = (*el_veto_id)[ref];
+        bool isPassVeto = (*el_veto_id)[ref] && el.passConversionVeto();
         bool isPassTight = (*el_tight_id)[ref];
         bool isPassMedium = (*el_medium_id)[ref];
         bool isPassLoose = (*el_loose_id)[ref];
         bool isPassHLT = (*el_hlt_id)[ref];
-
-        if (not isPassVeto ) continue;
 
         myLepton l;
         l.pdgId = -el.charge()*11;
@@ -184,6 +194,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
 
         l.selBits = 0 ;
 
+        l.selBits |= unsigned(LepBaseline);
         l.selBits |= unsigned(isPassTight) * LepTight;
         l.selBits |= unsigned(isPassMedium) * LepMedium;
         l.selBits |= unsigned(isPassVeto) * LepVeto;
@@ -205,6 +216,7 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
         l.puiso  = puChIso;
         l.miniiso = getPFMiniIsolation_DeltaBeta(pf_->handle, dynamic_cast<const reco::Candidate *>(&el), 0.05, 0.2, 10., false) ;
 
+        if ( not (l.selBits & kMinId) ) continue;
         leptons.push_back(l);
 
     }

--- a/Nero/src/NeroLeptons.cpp
+++ b/Nero/src/NeroLeptons.cpp
@@ -87,7 +87,9 @@ int NeroLeptons::analyze(const edm::Event & iEvent)
                 l.selBits |= unsigned(mu.isSoftMuon(* vtx_->GetPV())) * LepSoftIP;
                 if(isFake){ l.selBits |= unsigned(mu.isTightMuon(* vtx_->GetPV()) * LepFake); }
                 }
-
+            l.selBits |= unsigned(mu.isStandAloneMuon() * MuStandalone);
+            l.selBits |= unsigned(mu.isTrackerMuon() * MuTracker);
+            l.selBits |= unsigned(mu.isGlobalMuon() * MuGlobal);
             
         l.pfPt = mu.pfP4().pt();
 

--- a/Nero/src/NeroPhotons.cpp
+++ b/Nero/src/NeroPhotons.cpp
@@ -34,6 +34,7 @@ unsigned NeroPhotons::idStringToEnum(std::string idString)
     else if (idString == "vloose25") { idEnum = PhoVLoose25; }
     else if (idString == "highpt") { idEnum = PhoHighPt; }
     else if (idString == "monoph") { idEnum = PhoMonophBaseline; }
+    else if (idString == "none")   { idEnum = PhoBaseline; }
     return idEnum;
 }
 
@@ -130,6 +131,7 @@ int NeroPhotons::analyze(const edm::Event& iEvent,const edm::EventSetup &iSetup)
 
         unsigned bits=0;
 
+        bits |= 1; // baseline bit
         bits |= isPassTight * PhoTight;
         bits |= isPassMedium * PhoMedium;
         bits |= isPassLoose * PhoLoose;


### PR DESCRIPTION
- Add lepton ID bits 11, 12, 13 for standalone, global, tracker muons
- Fill muon veto ID bit using loose ID
- Allow photon ID "none" to be used as the minimum ID
- Implement minimum lepton ID in Nero config file, default is veto ID
- Absorb conversion veto requirement into electron veto ID
- Add a new config file which includes >10 GeV photons with no ID requirement beyond miniAOD slimmedPhotons, and >10 GeV leptons with no requirements such as conversion veto

(Guillelmo's PR from today is accounted for)