### PR TITLE
updating the met variables for the re-miniaod output

### DIFF
--- a/Core/interface/BareMet.hpp
+++ b/Core/interface/BareMet.hpp
@@ -37,6 +37,8 @@ class BareMet : virtual public BareP4
     
         TLorentzVector *metPuppi{0};
         TLorentzVector *metCleanMu{0};
+        TLorentzVector *metCleanEG{0};
+        TLorentzVector *metUnClean{0};
         // --- SYSTEMATICS -- //
         enum Syst{ JesUp= 0 , JesDown, JerUp,JerDown,UnclusterUp, UnclusterDown, TauUp, TauDown, PhotonUp, PhotonDown , ElectronUp, ElectronDown, MuonUp, MuonDown,  MaxSyst};
 

--- a/Core/src/BareMet.cpp
+++ b/Core/src/BareMet.cpp
@@ -9,6 +9,8 @@ BareMet::~BareMet(){
     BareFunctions::Delete(genP4);
     BareFunctions::Delete(metNoMu);
     BareFunctions::Delete(metCleanMu);
+    BareFunctions::Delete(metCleanEG);
+    BareFunctions::Delete(metUnClean);
     BareFunctions::Delete(metPuppi);
     BareFunctions::Delete(metPuppiSyst);
     BareFunctions::Delete(metSyst);
@@ -28,6 +30,8 @@ void BareMet::init(){
 
     BareFunctions::New(genP4);
     BareFunctions::New(metCleanMu);
+    BareFunctions::New(metCleanEG);
+    BareFunctions::New(metUnClean);
     BareFunctions::New(metPuppi);
     BareFunctions::New(metPuppiSyst);
     BareFunctions::New(metSyst);
@@ -53,6 +57,8 @@ void BareMet::clear(){
     genP4 -> Clear();
     *metPuppi *= 0;
     *metCleanMu *= 0;
+    *metCleanEG *= 0;
+    *metUnClean *= 0;
     metPuppiSyst->Clear();
     metSyst->Clear();
     *CaloMet *= 0.;
@@ -76,6 +82,8 @@ void BareMet::defineBranches(TTree *t){
     t->Branch("metP4_GEN","TClonesArray", &genP4, 128000, 0);
     //
     t->Branch("metCleanMu","TLorentzVector",&metCleanMu);
+    t->Branch("metCleanEG","TLorentzVector",&metCleanEG);
+    t->Branch("metUnClean","TLorentzVector",&metUnClean);
     t->Branch("metPuppi","TLorentzVector",&metPuppi);
     t->Branch("metPuppiSyst","TClonesArray",&metPuppiSyst,128000,0);
     t->Branch("metSyst","TClonesArray",&metSyst,128000,0);
@@ -102,6 +110,8 @@ void BareMet::setBranchAddresses(TTree *t){
 
     BareFunctions::SetBranchAddress(t,"metP4_GEN"	, &genP4 );
     BareFunctions::SetBranchAddress(t,"metCleanMu", &metCleanMu);
+    BareFunctions::SetBranchAddress(t,"metCleanEG", &metCleanEG);
+    BareFunctions::SetBranchAddress(t,"metUnClean", &metUnClean);
     BareFunctions::SetBranchAddress(t,"metPuppi", &metPuppi);
     BareFunctions::SetBranchAddress(t,"metPuppiSyst", &metPuppiSyst);
     BareFunctions::SetBranchAddress(t,"metSyst", &metSyst);
@@ -128,6 +138,8 @@ void BareMet::compress(){
 		BareFunctions::Compress( * (TLorentzVector*) genP4->At(i)  );
 
     BareFunctions::Compress(*metCleanMu);
+    BareFunctions::Compress(*metCleanEG);
+    BareFunctions::Compress(*metUnClean);
 
     BareFunctions::Compress(*metPuppi);
 

--- a/Nero/interface/NeroMet.hpp
+++ b/Nero/interface/NeroMet.hpp
@@ -20,11 +20,15 @@ class NeroMet : virtual public NeroCollection,
         edm::Handle<pat::METCollection> handle;	
         edm::Handle<pat::METCollection> handle_puppi;
         edm::Handle<pat::METCollection> handle_cleanmu;
+        edm::Handle<pat::METCollection> handle_cleaneg;
+        edm::Handle<pat::METCollection> handle_unclean;
 
         // --- Token
         edm::EDGetTokenT<pat::METCollection> token;
         edm::EDGetTokenT<pat::METCollection> token_puppi;
         edm::EDGetTokenT<pat::METCollection> token_cleanmu;
+        edm::EDGetTokenT<pat::METCollection> token_cleaneg;
+        edm::EDGetTokenT<pat::METCollection> token_unclean;
         //
         NeroPF * pf;
 };

--- a/Nero/plugins/Nero.cc
+++ b/Nero/plugins/Nero.cc
@@ -203,6 +203,8 @@ Nero::Nero(const edm::ParameterSet& iConfig)
     met -> pf = pf;
     met -> token_puppi = consumes<pat::METCollection>(iConfig.getParameter<edm::InputTag>("metsPuppi"));
     met -> token_cleanmu = consumes<pat::METCollection>(iConfig.getParameter<edm::InputTag>("metscleanmu"));
+    met -> token_cleaneg = consumes<pat::METCollection>(iConfig.getParameter<edm::InputTag>("metscleaneg"));
+    met -> token_unclean = consumes<pat::METCollection>(iConfig.getParameter<edm::InputTag>("metsunclean"));
     met -> SetExtend (iConfig.getParameter<bool>("extendMet"));
     obj.push_back(met);
 

--- a/Nero/python/Nero_cfi.py
+++ b/Nero/python/Nero_cfi.py
@@ -18,9 +18,17 @@ nero = cms.EDAnalyzer("Nero",
     puppijets = cms.InputTag("slimmedJetsPuppi"),
 
     ## Always re-corrected therefore re-run
-    mets = cms.InputTag("slimmedMETs"),
+
+    ## default met for nero is the mu+eg cleaned
+    mets = cms.InputTag("slimmedMETsMuEGClean"),
     metsPuppi = cms.InputTag("slimmedMETsPuppi"),
-    metscleanmu = cms.InputTag("slimmedMETsMuClean"),
+
+    #This is unclean only in reminiaod data
+    metsunclean = cms.InputTag("slimmedMETsUncorrected"),
+    #This is mu clean only in reminiaod data
+    metscleanmu = cms.InputTag("slimmedMETs"),
+    #This is eg clean only in reminiaod data
+    metscleaneg = cms.InputTag("slimmedMETsEGClean"),
 
     ## Directly taken from miniaod
     chsAK8 = cms.InputTag("slimmedJetsAK8"),

--- a/Nero/src/NeroMet.cpp
+++ b/Nero/src/NeroMet.cpp
@@ -27,6 +27,25 @@ int NeroMet::analyze(const edm::Event& iEvent){
     iEvent.getByToken(token_cleanmu,handle_cleanmu);
     if ( not handle_cleanmu.isValid() ) cout<<"[NeroMet]::[analyze]::[ERROR] handle_cleanmu is not valid"<<endl;
 
+
+    if ( iEvent.isRealData () ){            
+        iEvent.getByToken(token_cleaneg,handle_cleaneg);
+        if ( not handle_cleaneg.isValid() ) cout<<"[NeroMet]::[analyze]::[ERROR] handle_cleaneg is not valid"<<endl;
+
+        iEvent.getByToken(token_unclean,handle_unclean);
+        if ( not handle_unclean.isValid() ) cout<<"[NeroMet]::[analyze]::[ERROR] handle_unclean is not valid"<<endl;
+
+        // FILL cleaneg MET
+        auto &cleaneg = handle_cleaneg->front(); 
+        *metCleanEG =  TLorentzVector( cleaneg.px(), cleaneg.py(),cleaneg.pz(),cleaneg.energy() );
+               
+        // FILL unclean MET
+        auto &unclean = handle_unclean->front(); 
+        *metUnClean =  TLorentzVector( unclean.px(), unclean.py(),unclean.pz(),unclean.energy() );
+       
+    }
+
+
     const pat::MET &met = handle->front();
 
     TLorentzVector caloMet(0,0,0,0);


### PR DESCRIPTION
This PR contains the new MET variables in different levels of cleaning for the re-miniaod data (also works for the mc)

In the monte carlo, the reclustering is done to get the mu correction on met. This would be useful for those of us who wants to study the mis-tagging efficiency. 

In summary the meaning of the collections are:

DATA:
* metP4 -> Muon and E/Gamma Cleaned
* metCleanMu -> Muon only Cleaned
* metCleanEG -> EGamma only Cleaned
* metUnClean -> original uncorrected MET collection

MC:
* metP4 -> original MET collection
* metCleanMu -> Re-clustered mu clean MET collection (to check the mis-tag rates)

In the analysis one would continue using metP4. If mistag rates are to be found too large, then one could reject the events.

@amarini , @GuillelmoGomezCeballos
Please confirm that you agree with this approach. And Andrea could you please add an appropriate tag if necessary?

Lastly, I am running a "large" scale test to hit couple of bad events to confirm all is changing as expected.


